### PR TITLE
[TASK] Use typo3/testing-framework 7 for core v11 and v12 testing

### DIFF
--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -226,7 +226,6 @@ services:
         fi
         if [ ${TYPO3_VERSION} -eq 12 ]; then
             composer config minimum-stability dev
-            composer req --dev typo3/testing-framework:dev-main --no-update
             composer req --dev typo3/cms-workspaces:~12.0@dev --no-update
             composer req typo3/cms-core:~12.0@dev -W
         fi


### PR DESCRIPTION
Testing against core v12 has been done with testing-framework main.
This is now changed so core v12 also uses typo3/testing-framework 7
to act as multi-core testing with the compatibility version.