### PR TITLE
[BUGFIX] PHP warning inline children point to invalid TCA table

### DIFF
--- a/.github/workflows/testscorev11.yml
+++ b/.github/workflows/testscorev11.yml
@@ -43,6 +43,9 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mysql -a pdo_mysql -s functional
 
       - name: Functional Tests with postgres
+        # v11 postgres functional disabled with PHP 8.2 since https://github.com/doctrine/dbal/commit/73eec6d882b99e1e2d2d937accca89c1bd91b2d7
+        # is not fixed in doctrine core v11 doctrine 2.13.9
+        if: ${{ matrix.php <= '8.1' }}
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
 
       - name: Functional Tests with sqlite

--- a/Build/FunctionalTests.xml
+++ b/Build/FunctionalTests.xml
@@ -24,7 +24,9 @@
         </testsuite>
     </testsuites>
     <php>
+        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true" />
         <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="E_ALL" />
         <env name="TYPO3_CONTEXT" value="Testing" />
     </php>
 </phpunit>

--- a/Classes/Health/InlineForeignFieldChildrenParentDeleted.php
+++ b/Classes/Health/InlineForeignFieldChildrenParentDeleted.php
@@ -69,7 +69,7 @@ class InlineForeignFieldChildrenParentDeleted extends AbstractHealth implements 
                 if (empty($inlineChildRow[$fieldNameOfParentTableName])
                     || (int)($inlineChildRow[$fieldNameOfParentTableUid]) === 0
                     // Parent TCA table must be defined and table must exist
-                    || !is_array($GLOBALS['TCA'][$inlineChildRow[$fieldNameOfParentTableName]])
+                    || !is_array($GLOBALS['TCA'][$inlineChildRow[$fieldNameOfParentTableName]] ?? false)
                     || !$tableHelper->tableExistsInDatabase((string)$inlineChildRow[$fieldNameOfParentTableName])
                 ) {
                     // This was handled by previous InlineForeignFieldChildrenParentMissing already.

--- a/Classes/Health/InlineForeignFieldChildrenParentLanguageDifferent.php
+++ b/Classes/Health/InlineForeignFieldChildrenParentLanguageDifferent.php
@@ -68,7 +68,7 @@ class InlineForeignFieldChildrenParentLanguageDifferent extends AbstractHealth i
                 if (empty($inlineChildRow[$fieldNameOfParentTableName])
                     || (int)($inlineChildRow[$fieldNameOfParentTableUid]) === 0
                     // Parent TCA table must be defined and table must exist
-                    || !is_array($GLOBALS['TCA'][$inlineChildRow[$fieldNameOfParentTableName]])
+                    || !is_array($GLOBALS['TCA'][$inlineChildRow[$fieldNameOfParentTableName]] ?? false)
                     || !$tableHelper->tableExistsInDatabase((string)$inlineChildRow[$fieldNameOfParentTableName])
                 ) {
                     // This was handled by previous InlineForeignFieldChildrenParentMissing already.

--- a/Classes/Health/InlineForeignFieldChildrenParentMissing.php
+++ b/Classes/Health/InlineForeignFieldChildrenParentMissing.php
@@ -62,7 +62,7 @@ class InlineForeignFieldChildrenParentMissing extends AbstractHealth implements 
                 if (empty($inlineChildRow[$fieldNameOfParentTableName])
                     || (int)($inlineChildRow[$fieldNameOfParentTableUid]) === 0
                     // Parent TCA table must be defined and table must exist
-                    || !is_array($GLOBALS['TCA'][$inlineChildRow[$fieldNameOfParentTableName]])
+                    || !is_array($GLOBALS['TCA'][$inlineChildRow[$fieldNameOfParentTableName]] ?? false)
                     || !$tableHelper->tableExistsInDatabase((string)$inlineChildRow[$fieldNameOfParentTableName])
                 ) {
                     $inlineChildRow['_reasonBroken'] = 'Invalid parent';


### PR DESCRIPTION
Fix a possible PHP 8 related array access warning when
inline children point to not existing TCA parent tables.
Fix functional test setup to not suppress warnings
to let tests fail properly.
Also disable functional core v11, postgres, PHP 8.2 testing
since it triggers a doctrine 2.13.9 deprecation.

Closes: #15