### PR TITLE
[TASK] Ensure core v12 testing works

### DIFF
--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -221,11 +221,15 @@ services:
         fi
         php -v | grep '^PHP';
         if [ ${TYPO3_VERSION} -eq 11 ]; then
+              composer rem --dev "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge" --no-update
+              composer req --dev "typo3/cms-composer-installers:^3.0" --no-update
               composer req --dev typo3/cms-workspaces:^11.5 --no-update
               composer req typo3/cms-core:^11.5 --no-update
         fi
         if [ ${TYPO3_VERSION} -eq 12 ]; then
             composer req --dev  --no-update \
+               "typo3/cms-composer-installers:^5.0" \
+               "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge":^0.0.1 \
                 typo3/cms-backend:~12.0@dev \
                 typo3/cms-recordlist:~12.0@dev \
                 typo3/cms-frontend:~12.0@dev \

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "bin-dir": ".Build/bin",
     "allow-plugins": {
       "typo3/class-alias-loader": true,
-      "typo3/cms-composer-installers": true
+      "typo3/cms-composer-installers": true,
+      "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true
     }
   },
   "require-dev": {


### PR DESCRIPTION
This changes requires the intermediate workaround composer plugin `sbuerk/typo3-cmscomposerinstallers-testingframework-bridge` to mitigate testing issues against TYPO3v12.

This only solves the generic composer installation for now. Sadly, due another change in core which removed database column from `sys_file_reference`, dbdoctor checks and corresponding tests are failing now due not existing table column.

See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/75916
