### PR TITLE
[TASK] Upgrade action/checkout to avoid deprecation message

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check tag
         run: |

--- a/.github/workflows/testscorev11.yml
+++ b/.github/workflows/testscorev11.yml
@@ -16,7 +16,7 @@ jobs:
         php: [ '7.4', '8.0', '8.1', '8.2' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install testing system
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t 11 -s composerUpdate

--- a/.github/workflows/testscorev12.yml
+++ b/.github/workflows/testscorev12.yml
@@ -16,7 +16,7 @@ jobs:
         php: [ '8.1', '8.2' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install testing system
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t 12 -s composerUpdate


### PR DESCRIPTION
GitHub has deprecated node v12 support for executing GitHub actions. This currently adds corresponding deprecation note to action results, also not failing for now.

This change updates action/checkout to use v3 instead of v2 to use Node v16 compatible version and thus avoiding the deprecation notice.

See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

![image](https://user-images.githubusercontent.com/1453466/195266883-e6912d88-ff0b-471f-802e-41547174280c.png)
