### PR TITLE
[TASK] Render output summary with "p" and "d" again

### DIFF
--- a/Classes/HealthCheck/AbstractHealthCheck.php
+++ b/Classes/HealthCheck/AbstractHealthCheck.php
@@ -126,9 +126,11 @@ abstract class AbstractHealthCheck
                     }
                     break;
                 case 'p':
+                    $this->outputMainSummary($io, $affectedRecords);
                     $this->affectedPages($io, $affectedRecords);
                     break;
                 case 'd':
+                    $this->outputMainSummary($io, $affectedRecords);
                     $this->recordDetails($io, $affectedRecords);
                     break;
                 case 'h':


### PR DESCRIPTION
To scroll less, it is helpful to output the
header summary each time when intaracting
with "p" and "d".