### PR TITLE
[BUGFIX] Allow running single test again

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -252,9 +252,6 @@ DOCKER_PHP_IMAGE=`echo "php${PHP_VERSION}" | sed -e 's/\.//'`
 # Set $1 to first mass argument, this is the optional test file or test directory to execute
 shift $((OPTIND - 1))
 TEST_FILE=${1}
-if [ -n "${1}" ]; then
-    TEST_FILE="Web/typo3conf/ext/dbdoctor/${1}"
-fi
 
 if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
     set -x


### PR DESCRIPTION
Minor change in runTests.sh to allow a test
file as argument and let phpunit find it
properly again.