### PR TITLE
[TASK] TcaHelper is a stateless service

### DIFF
--- a/Classes/HealthCheck/AbstractHealthCheck.php
+++ b/Classes/HealthCheck/AbstractHealthCheck.php
@@ -45,6 +45,7 @@ abstract class AbstractHealthCheck
 
     protected ContainerInterface $container;
     protected ConnectionPool $connectionPool;
+    protected TcaHelper $tcaHelper;
 
     public function injectContainer(ContainerInterface $container): void
     {
@@ -54,6 +55,11 @@ abstract class AbstractHealthCheck
     public function injectConnectionPool(ConnectionPool $connectionPool): void
     {
         $this->connectionPool = $connectionPool;
+    }
+
+    public function injectTcaHelper(TcaHelper $tcaHelper): void
+    {
+        $this->tcaHelper = $tcaHelper;
     }
 
     public function handle(SymfonyStyle $io, int $mode, string $file): int
@@ -317,8 +323,6 @@ abstract class AbstractHealthCheck
      */
     protected function softOrHardDeleteRecords(SymfonyStyle $io, bool $simulate, string $tableName, array $rows): void
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
         if ($simulate) {
@@ -327,7 +331,7 @@ abstract class AbstractHealthCheck
             $io->note('Handle records on table: ' . $tableName);
         }
 
-        $deleteField = $tcaHelper->getDeletedField($tableName);
+        $deleteField = $this->tcaHelper->getDeletedField($tableName);
         $isTableSoftDeleteAware = !empty($deleteField);
         $updateFields = [];
         if ($isTableSoftDeleteAware) {
@@ -338,7 +342,7 @@ abstract class AbstractHealthCheck
                 ],
             ];
         }
-        $workspaceIdField = $tcaHelper->getWorkspaceIdField($tableName);
+        $workspaceIdField = $this->tcaHelper->getWorkspaceIdField($tableName);
         $isTableWorkspaceAware = !empty($workspaceIdField);
 
         $updateCount = 0;

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentDeleted.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentDeleted.php
@@ -20,7 +20,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 use Lolli\Dbdoctor\Helper\RecordsHelper;
 use Lolli\Dbdoctor\Helper\TableHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -43,21 +42,19 @@ class InlineForeignFieldChildrenParentDeleted extends AbstractHealthCheck implem
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
         /** @var TableHelper $tableHelper */
         $tableHelper = $this->container->get(TableHelper::class);
 
         $affectedRows = [];
-        foreach ($tcaHelper->getNextInlineForeignFieldChildTcaTable() as $inlineChild) {
+        foreach ($this->tcaHelper->getNextInlineForeignFieldChildTcaTable() as $inlineChild) {
             $childTableName = $inlineChild['tableName'];
-            if (!$tcaHelper->getDeletedField($childTableName)) {
+            if (!$this->tcaHelper->getDeletedField($childTableName)) {
                 // Skip child table if it is not soft-delete aware
                 continue;
             }
-            $workspaceIdField = $tcaHelper->getWorkspaceIdField($childTableName);
+            $workspaceIdField = $this->tcaHelper->getWorkspaceIdField($childTableName);
             $isTableWorkspaceAware = !empty($workspaceIdField);
             $fieldNameOfParentTableName = $inlineChild['fieldNameOfParentTableName'];
             $fieldNameOfParentTableUid = $inlineChild['fieldNameOfParentTableUid'];
@@ -88,7 +85,7 @@ class InlineForeignFieldChildrenParentDeleted extends AbstractHealthCheck implem
                     continue;
                 }
                 $parentTableName = (string)$inlineChildRow[$fieldNameOfParentTableName];
-                $parentTableDeleteField = $tcaHelper->getDeletedField($parentTableName);
+                $parentTableDeleteField = $this->tcaHelper->getDeletedField($parentTableName);
                 if (!$parentTableDeleteField) {
                     // Skip if parent table is not soft-delete aware
                     continue;

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferent.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferent.php
@@ -20,7 +20,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 use Lolli\Dbdoctor\Helper\RecordsHelper;
 use Lolli\Dbdoctor\Helper\TableHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -40,17 +39,15 @@ class InlineForeignFieldChildrenParentLanguageDifferent extends AbstractHealthCh
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
         /** @var TableHelper $tableHelper */
         $tableHelper = $this->container->get(TableHelper::class);
 
         $affectedRows = [];
-        foreach ($tcaHelper->getNextInlineForeignFieldChildTcaTable() as $inlineChild) {
+        foreach ($this->tcaHelper->getNextInlineForeignFieldChildTcaTable() as $inlineChild) {
             $childTableName = $inlineChild['tableName'];
-            $childTableLanguageField = $tcaHelper->getLanguageField($childTableName);
+            $childTableLanguageField = $this->tcaHelper->getLanguageField($childTableName);
             if (!$childTableLanguageField) {
                 // Skip child table if it is not localizable
                 continue;
@@ -75,7 +72,7 @@ class InlineForeignFieldChildrenParentLanguageDifferent extends AbstractHealthCh
                     continue;
                 }
                 $parentTableName = (string)$inlineChildRow[$fieldNameOfParentTableName];
-                $parentTableLanguageField = $tcaHelper->getLanguageField($parentTableName);
+                $parentTableLanguageField = $this->tcaHelper->getLanguageField($parentTableName);
                 if (!$parentTableLanguageField) {
                     // Skip if parent table is not localizable
                     continue;
@@ -104,12 +101,10 @@ class InlineForeignFieldChildrenParentLanguageDifferent extends AbstractHealthCh
 
     protected function processRecords(SymfonyStyle $io, bool $simulate, array $affectedRecords): void
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
         foreach ($affectedRecords as $childTableName => $childTableRows) {
-            $childLanguageField = $tcaHelper->getLanguageField($childTableName);
+            $childLanguageField = $this->tcaHelper->getLanguageField($childTableName);
             foreach ($childTableRows as $childTableRow) {
                 $updateFields = [
                     $childLanguageField => [

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentMissing.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentMissing.php
@@ -20,7 +20,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 use Lolli\Dbdoctor\Helper\RecordsHelper;
 use Lolli\Dbdoctor\Helper\TableHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -39,15 +38,13 @@ class InlineForeignFieldChildrenParentMissing extends AbstractHealthCheck implem
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
         /** @var TableHelper $tableHelper */
         $tableHelper = $this->container->get(TableHelper::class);
 
         $affectedRows = [];
-        foreach ($tcaHelper->getNextInlineForeignFieldChildTcaTable() as $inlineChild) {
+        foreach ($this->tcaHelper->getNextInlineForeignFieldChildTcaTable() as $inlineChild) {
             $childTableName = $inlineChild['tableName'];
             $fieldNameOfParentTableName = $inlineChild['fieldNameOfParentTableName'];
             $fieldNameOfParentTableUid = $inlineChild['fieldNameOfParentTableUid'];

--- a/Classes/HealthCheck/SysFileReferenceInvalidFieldname.php
+++ b/Classes/HealthCheck/SysFileReferenceInvalidFieldname.php
@@ -18,7 +18,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
  */
 
 use Lolli\Dbdoctor\Helper\TableHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -49,8 +48,6 @@ class SysFileReferenceInvalidFieldname extends AbstractHealthCheck implements He
     {
         /** @var TableHelper $tableHelper */
         $tableHelper = $this->container->get(TableHelper::class);
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         $tableRows = [];
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_file_reference');
         // We consider deleted=1 records too to remove them if they're invalid.
@@ -61,7 +58,7 @@ class SysFileReferenceInvalidFieldname extends AbstractHealthCheck implements He
         while ($row = $result->fetchAssociative()) {
             /** @var array<string, int|string> $row */
             if (!$tableHelper->fieldExistsInTable((string)$row['tablenames'], (string)$row['fieldname'])
-                && !$tcaHelper->hasFlexField((string)$row['tablenames'])
+                && !$this->tcaHelper->hasFlexField((string)$row['tablenames'])
             ) {
                 // @todo: FAL fields can be bound to TCA flex. For those, fieldname is set to single flex
                 //        data structure fields names. (see styleguide_inline_fal flex example) To find out

--- a/Classes/HealthCheck/TcaTablesDeleteFlagZeroOrOne.php
+++ b/Classes/HealthCheck/TcaTablesDeleteFlagZeroOrOne.php
@@ -17,7 +17,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -38,11 +37,9 @@ class TcaTablesDeleteFlagZeroOrOne extends AbstractHealthCheck implements Health
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         $affectedRows = [];
-        foreach ($tcaHelper->getNextSoftDeleteAwareTable() as $tableName) {
-            $tableDeleteField = $tcaHelper->getDeletedField($tableName);
+        foreach ($this->tcaHelper->getNextSoftDeleteAwareTable() as $tableName) {
+            $tableDeleteField = $this->tcaHelper->getDeletedField($tableName);
             if (empty($tableDeleteField)) {
                 throw new \RuntimeException(
                     'The delete field must not be empty. This exception indicates a bug in getNextSoftDeleteAwareTable()',
@@ -67,11 +64,9 @@ class TcaTablesDeleteFlagZeroOrOne extends AbstractHealthCheck implements Health
 
     protected function processRecords(SymfonyStyle $io, bool $simulate, array $affectedRecords): void
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         foreach ($affectedRecords as $tableName => $tableRows) {
             // Force "deleted=1" for affected rows.
-            $deletedField = $tcaHelper->getDeletedField($tableName);
+            $deletedField = $this->tcaHelper->getDeletedField($tableName);
             $updateFields = [
                 $deletedField => [
                     'value' => 1,

--- a/Classes/HealthCheck/TcaTablesInvalidLanguageParent.php
+++ b/Classes/HealthCheck/TcaTablesInvalidLanguageParent.php
@@ -19,7 +19,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
 
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 use Lolli\Dbdoctor\Helper\RecordsHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -43,18 +42,16 @@ class TcaTablesInvalidLanguageParent extends AbstractHealthCheck implements Heal
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
 
         $danglingRows = [];
-        foreach ($tcaHelper->getNextLanguageAwareTcaTable() as $tableName) {
+        foreach ($this->tcaHelper->getNextLanguageAwareTcaTable() as $tableName) {
             /** @var string $languageField */
-            $languageField = $tcaHelper->getLanguageField($tableName);
+            $languageField = $this->tcaHelper->getLanguageField($tableName);
             /** @var string $translationParentField */
-            $translationParentField = $tcaHelper->getTranslationParentField($tableName);
-            $deletedField = $tcaHelper->getDeletedField($tableName);
+            $translationParentField = $this->tcaHelper->getTranslationParentField($tableName);
+            $deletedField = $this->tcaHelper->getDeletedField($tableName);
 
             $parentRowFields = [
                 'uid',

--- a/Classes/HealthCheck/TcaTablesPidDeleted.php
+++ b/Classes/HealthCheck/TcaTablesPidDeleted.php
@@ -19,7 +19,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
 
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 use Lolli\Dbdoctor\Helper\RecordsHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -41,15 +40,13 @@ class TcaTablesPidDeleted extends AbstractHealthCheck implements HealthCheckInte
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
 
         $affectedRows = [];
         // Iterate all TCA tables, but ignore pages table
-        foreach ($tcaHelper->getNextTcaTable(['pages']) as $tableName) {
-            $workspaceIdField = $tcaHelper->getWorkspaceIdField($tableName);
+        foreach ($this->tcaHelper->getNextTcaTable(['pages']) as $tableName) {
+            $workspaceIdField = $this->tcaHelper->getWorkspaceIdField($tableName);
             $isTableWorkspaceAware = !empty($workspaceIdField);
             $selectFields = ['uid', 'pid'];
             if ($isTableWorkspaceAware) {
@@ -60,7 +57,7 @@ class TcaTablesPidDeleted extends AbstractHealthCheck implements HealthCheckInte
             $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
             $queryBuilder->select(...$selectFields)->from($tableName)->orderBy('uid');
             $queryBuilder->where($queryBuilder->expr()->gt('pid', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)));
-            $tableDeleteField = $tcaHelper->getDeletedField($tableName);
+            $tableDeleteField = $this->tcaHelper->getDeletedField($tableName);
             if ($tableDeleteField) {
                 // Do not consider deleted records: Records pointing to a not-existing page have been
                 // caught before, we want to find non-deleted records pointing to deleted pages.

--- a/Classes/HealthCheck/TcaTablesPidMissing.php
+++ b/Classes/HealthCheck/TcaTablesPidMissing.php
@@ -19,7 +19,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
 
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 use Lolli\Dbdoctor\Helper\RecordsHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -38,13 +37,11 @@ class TcaTablesPidMissing extends AbstractHealthCheck implements HealthCheckInte
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
 
         $affectedRows = [];
-        foreach ($tcaHelper->getNextTcaTable(['pages', 'sys_workspace']) as $tableName) {
+        foreach ($this->tcaHelper->getNextTcaTable(['pages', 'sys_workspace']) as $tableName) {
             // Iterate all TCA tables, but ignore pages table
             $queryBuilder = $this->connectionPool->getQueryBuilderForTable($tableName);
             // Consider deleted records: If the pid does not exist, they should be deleted, too.

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDeleted.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDeleted.php
@@ -19,7 +19,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
 
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 use Lolli\Dbdoctor\Helper\RecordsHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -42,24 +41,22 @@ class TcaTablesTranslatedLanguageParentDeleted extends AbstractHealthCheck imple
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
 
         $affectedRows = [];
-        foreach ($tcaHelper->getNextLanguageAwareTcaTable(['pages']) as $tableName) {
-            $deletedField = $tcaHelper->getDeletedField($tableName);
+        foreach ($this->tcaHelper->getNextLanguageAwareTcaTable(['pages']) as $tableName) {
+            $deletedField = $this->tcaHelper->getDeletedField($tableName);
             if (!$deletedField) {
                 // Ignore tables without delete field.
                 continue;
             }
 
             /** @var string $languageField */
-            $languageField = $tcaHelper->getLanguageField($tableName);
+            $languageField = $this->tcaHelper->getLanguageField($tableName);
             /** @var string $translationParentField */
-            $translationParentField = $tcaHelper->getTranslationParentField($tableName);
-            $workspaceIdField = $tcaHelper->getWorkspaceIdField($tableName);
+            $translationParentField = $this->tcaHelper->getTranslationParentField($tableName);
+            $workspaceIdField = $this->tcaHelper->getWorkspaceIdField($tableName);
             $isTableWorkspaceAware = !empty($workspaceIdField);
 
             $selectFields = [

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPid.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPid.php
@@ -19,7 +19,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
 
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 use Lolli\Dbdoctor\Helper\RecordsHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -43,18 +42,16 @@ class TcaTablesTranslatedLanguageParentDifferentPid extends AbstractHealthCheck 
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
 
         $affectedRows = [];
-        foreach ($tcaHelper->getNextLanguageAwareTcaTable(['pages']) as $tableName) {
+        foreach ($this->tcaHelper->getNextLanguageAwareTcaTable(['pages']) as $tableName) {
             /** @var string $languageField */
-            $languageField = $tcaHelper->getLanguageField($tableName);
+            $languageField = $this->tcaHelper->getLanguageField($tableName);
             /** @var string $translationParentField */
-            $translationParentField = $tcaHelper->getTranslationParentField($tableName);
-            $workspaceIdField = $tcaHelper->getWorkspaceIdField($tableName);
+            $translationParentField = $this->tcaHelper->getTranslationParentField($tableName);
+            $workspaceIdField = $this->tcaHelper->getWorkspaceIdField($tableName);
             $isTableWorkspaceAware = !empty($workspaceIdField);
 
             $selectFields = [
@@ -103,8 +100,6 @@ class TcaTablesTranslatedLanguageParentDifferentPid extends AbstractHealthCheck 
 
     protected function processRecords(SymfonyStyle $io, bool $simulate, array $affectedRecords): void
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
         foreach ($affectedRecords as $tableName => $tableRows) {
@@ -116,15 +111,15 @@ class TcaTablesTranslatedLanguageParentDifferentPid extends AbstractHealthCheck 
             $updateCount = 0;
             $deleteCount = 0;
 
-            $deleteField = $tcaHelper->getDeletedField($tableName);
+            $deleteField = $this->tcaHelper->getDeletedField($tableName);
             $isTableSoftDeleteAware = !empty($deleteField);
-            $hiddenField = $tcaHelper->getHiddenField($tableName);
+            $hiddenField = $this->tcaHelper->getHiddenField($tableName);
             $isTableHiddenAware = !empty($hiddenField);
             /** @var string $languageField */
-            $languageField = $tcaHelper->getLanguageField($tableName);
+            $languageField = $this->tcaHelper->getLanguageField($tableName);
             /** @var string $translationParentField */
-            $translationParentField = $tcaHelper->getTranslationParentField($tableName);
-            $workspaceIdField = $tcaHelper->getWorkspaceIdField($tableName);
+            $translationParentField = $this->tcaHelper->getTranslationParentField($tableName);
+            $workspaceIdField = $this->tcaHelper->getWorkspaceIdField($tableName);
             $isTableWorkspaceAware = !empty($workspaceIdField);
 
             foreach ($tableRows as $localizedRow) {

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentMissing.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentMissing.php
@@ -19,7 +19,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
 
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 use Lolli\Dbdoctor\Helper\RecordsHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -40,17 +39,15 @@ class TcaTablesTranslatedLanguageParentMissing extends AbstractHealthCheck imple
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
 
         $affectedRows = [];
-        foreach ($tcaHelper->getNextLanguageAwareTcaTable(['pages']) as $tableName) {
+        foreach ($this->tcaHelper->getNextLanguageAwareTcaTable(['pages']) as $tableName) {
             /** @var string $languageField */
-            $languageField = $tcaHelper->getLanguageField($tableName);
+            $languageField = $this->tcaHelper->getLanguageField($tableName);
             /** @var string $translationParentField */
-            $translationParentField = $tcaHelper->getTranslationParentField($tableName);
+            $translationParentField = $this->tcaHelper->getTranslationParentField($tableName);
 
             $queryBuilder = $this->connectionPool->getQueryBuilderForTable($tableName);
             // Handle deleted=1 records too: If their language parent is gone, they shouldn't exist anymore, too.

--- a/Classes/HealthCheck/TcaTablesTranslatedParentInvalidPointer.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedParentInvalidPointer.php
@@ -19,7 +19,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
 
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 use Lolli\Dbdoctor\Helper\RecordsHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -43,17 +42,15 @@ class TcaTablesTranslatedParentInvalidPointer extends AbstractHealthCheck implem
 
     protected function getAffectedRecords(): array
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
 
         $affectedRows = [];
-        foreach ($tcaHelper->getNextLanguageAwareTcaTable(['pages']) as $tableName) {
+        foreach ($this->tcaHelper->getNextLanguageAwareTcaTable(['pages']) as $tableName) {
             /** @var string $languageField */
-            $languageField = $tcaHelper->getLanguageField($tableName);
+            $languageField = $this->tcaHelper->getLanguageField($tableName);
             /** @var string $translationParentField */
-            $translationParentField = $tcaHelper->getTranslationParentField($tableName);
+            $translationParentField = $this->tcaHelper->getTranslationParentField($tableName);
 
             $parentRowFields = [
                 'uid',
@@ -93,14 +90,12 @@ class TcaTablesTranslatedParentInvalidPointer extends AbstractHealthCheck implem
 
     protected function processRecords(SymfonyStyle $io, bool $simulate, array $affectedRecords): void
     {
-        /** @var TcaHelper $tcaHelper */
-        $tcaHelper = $this->container->get(TcaHelper::class);
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
         foreach ($affectedRecords as $tableName => $affectedTableRecords) {
             foreach ($affectedTableRecords as $affectedTableRecord) {
                 /** @var string $translationParentField */
-                $translationParentField = $tcaHelper->getTranslationParentField($tableName);
+                $translationParentField = $this->tcaHelper->getTranslationParentField($tableName);
                 $parentRow = $recordsHelper->getRecord($tableName, ['uid', $translationParentField], (int)$affectedTableRecord[$translationParentField]);
                 $fields = [
                     $translationParentField => [

--- a/Classes/HealthCheck/WorkspacesNotLoadedRecordsDangling.php
+++ b/Classes/HealthCheck/WorkspacesNotLoadedRecordsDangling.php
@@ -17,7 +17,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
@@ -49,8 +48,7 @@ class WorkspacesNotLoadedRecordsDangling extends AbstractHealthCheck implements 
             return [];
         }
         $affectedRows = [];
-        $tcaHelper = $this->container->get(TcaHelper::class);
-        foreach ($tcaHelper->getNextWorkspaceEnabledTcaTable() as $tableName) {
+        foreach ($this->tcaHelper->getNextWorkspaceEnabledTcaTable() as $tableName) {
             $queryBuilder = $this->connectionPool->getQueryBuilderForTable($tableName);
             // Delete "deleted=1" records as well, when they have t3ver_wsid != 0
             $queryBuilder->getRestrictions()->removeAll();

--- a/Classes/HealthCheck/WorkspacesRecordsOfDeletedWorkspaces.php
+++ b/Classes/HealthCheck/WorkspacesRecordsOfDeletedWorkspaces.php
@@ -18,7 +18,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
  */
 
 use Lolli\Dbdoctor\Helper\TableHelper;
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -54,8 +53,7 @@ class WorkspacesRecordsOfDeletedWorkspaces extends AbstractHealthCheck implement
         }
         $allowedWorkspacesUids = $this->getAllowedWorkspaces();
         $affectedRows = [];
-        $tcaHelper = $this->container->get(TcaHelper::class);
-        foreach ($tcaHelper->getNextWorkspaceEnabledTcaTable() as $tableName) {
+        foreach ($this->tcaHelper->getNextWorkspaceEnabledTcaTable() as $tableName) {
             $queryBuilder = $this->connectionPool->getQueryBuilderForTable($tableName);
             // Since workspace records have no deleted=1, we remove all restrictions here: If a sys_workspace
             // has been removed at some point, there shouldn't be *any* records assigned to this workspace.

--- a/Classes/HealthCheck/WorkspacesSoftDeletedRecords.php
+++ b/Classes/HealthCheck/WorkspacesSoftDeletedRecords.php
@@ -17,7 +17,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Lolli\Dbdoctor\Helper\TcaHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
@@ -46,9 +45,8 @@ class WorkspacesSoftDeletedRecords extends AbstractHealthCheck implements Health
             return [];
         }
         $affectedRows = [];
-        $tcaHelper = $this->container->get(TcaHelper::class);
-        foreach ($tcaHelper->getNextWorkspaceEnabledTcaTable() as $tableName) {
-            $tableDeleteField = $tcaHelper->getDeletedField($tableName);
+        foreach ($this->tcaHelper->getNextWorkspaceEnabledTcaTable() as $tableName) {
+            $tableDeleteField = $this->tcaHelper->getDeletedField($tableName);
             if (empty($tableDeleteField)) {
                 // Table is not soft-delete aware. Skip it.
                 continue;

--- a/Classes/Helper/TcaHelper.php
+++ b/Classes/Helper/TcaHelper.php
@@ -19,6 +19,9 @@ namespace Lolli\Dbdoctor\Helper;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * Stateless helper service for various TCA details.
+ */
 class TcaHelper
 {
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -15,10 +15,6 @@ services:
     public: true
     shared: false
 
-  Lolli\Dbdoctor\Helper\TcaHelper:
-    public: true
-    shared: false
-
   Lolli\Dbdoctor\Helper\TableHelper:
     public: true
     shared: false

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ instance. As such, a few things should be kept in mind:
 $ bin/typo3 dbdoctor:health
 ```
 
+Note dbdoctor is "runtime static" with TCA: When dbdoctor is running, TCA is **not**
+expected to change meanwhile. When you are looking at single changes and decide to change
+TCA, then clear all caches and abort dbdoctor (press "a" in  interactive mode) to
+start again. Failing to do so may lead to dbdoctor committing hazard to the database,
+depending on what you did with TCA.
+
 The interface looks like this:
 
 ![](Documentation/cli-example.png)


### PR DESCRIPTION
TCA is considered static during dbdoctor execution. Inject TcaHelper to AbstractHealthCheck, and mark
it a shared service. No need to make it public, either.