### PR TITLE
[TASK] Declare codebase final

### DIFF
--- a/Classes/Commands/HealthCommand.php
+++ b/Classes/Commands/HealthCommand.php
@@ -30,7 +30,7 @@ use TYPO3\CMS\Core\Utility\PathUtility;
 /**
  * Main CLI entry point
  */
-class HealthCommand extends Command
+final class HealthCommand extends Command
 {
     private HealthFactoryInterface $healthFactory;
     private DatabaseSchemaChecker $databaseSchemaChecker;

--- a/Classes/DatabaseSchema/DatabaseSchemaChecker.php
+++ b/Classes/DatabaseSchema/DatabaseSchemaChecker.php
@@ -20,7 +20,7 @@ namespace Lolli\Dbdoctor\DatabaseSchema;
 use TYPO3\CMS\Core\Database\Schema\SchemaMigrator;
 use TYPO3\CMS\Core\Database\Schema\SqlReader;
 
-class DatabaseSchemaChecker
+final class DatabaseSchemaChecker
 {
     private SqlReader $sqlReader;
     private SchemaMigrator $schemaMigrator;

--- a/Classes/Exception/NoSuchPageException.php
+++ b/Classes/Exception/NoSuchPageException.php
@@ -19,6 +19,6 @@ namespace Lolli\Dbdoctor\Exception;
 
 use Lolli\Dbdoctor\Exception;
 
-class NoSuchPageException extends Exception
+final class NoSuchPageException extends Exception
 {
 }

--- a/Classes/Exception/NoSuchRecordException.php
+++ b/Classes/Exception/NoSuchRecordException.php
@@ -19,6 +19,6 @@ namespace Lolli\Dbdoctor\Exception;
 
 use Lolli\Dbdoctor\Exception;
 
-class NoSuchRecordException extends Exception
+final class NoSuchRecordException extends Exception
 {
 }

--- a/Classes/Exception/NoSuchTableException.php
+++ b/Classes/Exception/NoSuchTableException.php
@@ -19,6 +19,6 @@ namespace Lolli\Dbdoctor\Exception;
 
 use Lolli\Dbdoctor\Exception;
 
-class NoSuchTableException extends Exception
+final class NoSuchTableException extends Exception
 {
 }

--- a/Classes/Exception/UnexpectedNumberOfAffectedRowsException.php
+++ b/Classes/Exception/UnexpectedNumberOfAffectedRowsException.php
@@ -19,6 +19,6 @@ namespace Lolli\Dbdoctor\Exception;
 
 use Lolli\Dbdoctor\Exception;
 
-class UnexpectedNumberOfAffectedRowsException extends Exception
+final class UnexpectedNumberOfAffectedRowsException extends Exception
 {
 }

--- a/Classes/HealthCheck/AbstractHealthCheck.php
+++ b/Classes/HealthCheck/AbstractHealthCheck.php
@@ -47,22 +47,22 @@ abstract class AbstractHealthCheck
     protected ConnectionPool $connectionPool;
     protected TcaHelper $tcaHelper;
 
-    public function injectContainer(ContainerInterface $container): void
+    final public function injectContainer(ContainerInterface $container): void
     {
         $this->container = $container;
     }
 
-    public function injectConnectionPool(ConnectionPool $connectionPool): void
+    final public function injectConnectionPool(ConnectionPool $connectionPool): void
     {
         $this->connectionPool = $connectionPool;
     }
 
-    public function injectTcaHelper(TcaHelper $tcaHelper): void
+    final public function injectTcaHelper(TcaHelper $tcaHelper): void
     {
         $this->tcaHelper = $tcaHelper;
     }
 
-    public function handle(SymfonyStyle $io, int $mode, string $file): int
+    final public function handle(SymfonyStyle $io, int $mode, string $file): int
     {
         $this->sqlDumpFile = $file;
         if ($mode === HealthCheckInterface::MODE_CHECK) {
@@ -181,7 +181,7 @@ abstract class AbstractHealthCheck
     /**
      * @param array<string, array<int, array<string, int|string>>> $danglingRows
      */
-    protected function outputMainSummary(SymfonyStyle $io, array $danglingRows): void
+    final protected function outputMainSummary(SymfonyStyle $io, array $danglingRows): void
     {
         if (!count($danglingRows)) {
             $io->success('No affected records found');
@@ -204,7 +204,7 @@ abstract class AbstractHealthCheck
     /**
      * @param array<string, array<int, array<string, int|string>>> $danglingRows
      */
-    protected function outputAffectedPages(SymfonyStyle $io, array $danglingRows): void
+    final protected function outputAffectedPages(SymfonyStyle $io, array $danglingRows): void
     {
         $io->note('Found records per page:');
         /** @var AffectedPagesRenderer $affectedPagesHelper */
@@ -217,7 +217,7 @@ abstract class AbstractHealthCheck
      * @param array<int, string> $extraCtrlFields
      * @param array<int, string> $extraDbFields
      */
-    protected function outputRecordDetails(
+    final protected function outputRecordDetails(
         SymfonyStyle $io,
         array $danglingRows,
         string $reasonField = '',
@@ -240,7 +240,7 @@ abstract class AbstractHealthCheck
      *
      * @param array<string, array<int, array<string, int|string>>> $danglingRows
      */
-    protected function deleteAllRecords(SymfonyStyle $io, bool $simulate, array $danglingRows): void
+    final protected function deleteAllRecords(SymfonyStyle $io, bool $simulate, array $danglingRows): void
     {
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
@@ -263,7 +263,7 @@ abstract class AbstractHealthCheck
         }
     }
 
-    protected function deleteSingleTcaRecord(
+    final protected function deleteSingleTcaRecord(
         SymfonyStyle $io,
         bool $simulate,
         RecordsHelper $recordsHelper,
@@ -278,7 +278,7 @@ abstract class AbstractHealthCheck
      * @param array<int, array<string, int|string>> $rows
      * @param array<string, array<string, int|string>> $fields
      */
-    protected function updateAllRecords(SymfonyStyle $io, bool $simulate, string $tableName, array $rows, array $fields): void
+    final protected function updateAllRecords(SymfonyStyle $io, bool $simulate, string $tableName, array $rows, array $fields): void
     {
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);
@@ -302,7 +302,7 @@ abstract class AbstractHealthCheck
     /**
      * @param array<string, array<string, int|string>> $fields
      */
-    protected function updateSingleTcaRecord(
+    final protected function updateSingleTcaRecord(
         SymfonyStyle $io,
         bool $simulate,
         RecordsHelper $recordsHelper,
@@ -321,7 +321,7 @@ abstract class AbstractHealthCheck
      *
      * @param array<int, array<string, int|string>> $rows
      */
-    protected function softOrHardDeleteRecords(SymfonyStyle $io, bool $simulate, string $tableName, array $rows): void
+    final protected function softOrHardDeleteRecords(SymfonyStyle $io, bool $simulate, string $tableName, array $rows): void
     {
         /** @var RecordsHelper $recordsHelper */
         $recordsHelper = $this->container->get(RecordsHelper::class);

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentDeleted.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentDeleted.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Handle inline foreign field children that are not deleted but parent is deleted.
  */
-class InlineForeignFieldChildrenParentDeleted extends AbstractHealthCheck implements HealthCheckInterface
+final class InlineForeignFieldChildrenParentDeleted extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferent.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferent.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Handle inline foreign field children that are set to a different sys_language_uid than their parent.
  */
-class InlineForeignFieldChildrenParentLanguageDifferent extends AbstractHealthCheck implements HealthCheckInterface
+final class InlineForeignFieldChildrenParentLanguageDifferent extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentMissing.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentMissing.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Inline foreign field children must have existing parent record.
  */
-class InlineForeignFieldChildrenParentMissing extends AbstractHealthCheck implements HealthCheckInterface
+final class InlineForeignFieldChildrenParentMissing extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/PagesBrokenTree.php
+++ b/Classes/HealthCheck/PagesBrokenTree.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * An important early check: Find pages that have no proper connection to the tree root.
  */
-class PagesBrokenTree extends AbstractHealthCheck implements HealthCheckInterface
+final class PagesBrokenTree extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/PagesTranslatedLanguageParentDeleted.php
+++ b/Classes/HealthCheck/PagesTranslatedLanguageParentDeleted.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Find not-deleted translated pages that have a sys_language_uid=0 parent set to deleted=1.
  */
-class PagesTranslatedLanguageParentDeleted extends AbstractHealthCheck implements HealthCheckInterface
+final class PagesTranslatedLanguageParentDeleted extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/PagesTranslatedLanguageParentDifferentPid.php
+++ b/Classes/HealthCheck/PagesTranslatedLanguageParentDifferentPid.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Find translated pages that are on a different pid than their no sys_language_uid=0 parent.
  */
-class PagesTranslatedLanguageParentDifferentPid extends AbstractHealthCheck implements HealthCheckInterface
+final class PagesTranslatedLanguageParentDifferentPid extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/PagesTranslatedLanguageParentMissing.php
+++ b/Classes/HealthCheck/PagesTranslatedLanguageParentMissing.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Find translated pages that have no sys_language_uid=0 parent.
  */
-class PagesTranslatedLanguageParentMissing extends AbstractHealthCheck implements HealthCheckInterface
+final class PagesTranslatedLanguageParentMissing extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/SysFileReferenceDangling.php
+++ b/Classes/HealthCheck/SysFileReferenceDangling.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * sys_file_reference rows where either uid_local or uid_foreign does not exist.
  */
-class SysFileReferenceDangling extends AbstractHealthCheck implements HealthCheckInterface
+final class SysFileReferenceDangling extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/SysFileReferenceInvalidFieldname.php
+++ b/Classes/HealthCheck/SysFileReferenceInvalidFieldname.php
@@ -32,7 +32,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *          column name of the parent table. That's probably problematic to do, but it
  *          seems at least the Backend can deal with this?
  */
-class SysFileReferenceInvalidFieldname extends AbstractHealthCheck implements HealthCheckInterface
+final class SysFileReferenceInvalidFieldname extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/SysFileReferenceInvalidPid.php
+++ b/Classes/HealthCheck/SysFileReferenceInvalidPid.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * All records in sys_file_reference must be on same pid as the parent record.
  */
-class SysFileReferenceInvalidPid extends AbstractHealthCheck implements HealthCheckInterface
+final class SysFileReferenceInvalidPid extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/SysFileReferenceInvalidTableLocal.php
+++ b/Classes/HealthCheck/SysFileReferenceInvalidTableLocal.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Information\Typo3Version;
  *
  * Note core v12 no longer provides field "table_local", this check is skipped in v12.
  */
-class SysFileReferenceInvalidTableLocal extends AbstractHealthCheck implements HealthCheckInterface
+final class SysFileReferenceInvalidTableLocal extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/SysFileReferenceLocalizedFieldSync.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedFieldSync.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Localized sys_file_reference records must have the same data in field 'tablenames' and 'fieldname' as its language parent.
  */
-class SysFileReferenceLocalizedFieldSync extends AbstractHealthCheck implements HealthCheckInterface
+final class SysFileReferenceLocalizedFieldSync extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/SysFileReferenceLocalizedParentDeleted.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedParentDeleted.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Not deleted localized sys_file_reference records must point to a sys_language_uid=0 parent that is not deleted.
  */
-class SysFileReferenceLocalizedParentDeleted extends AbstractHealthCheck implements HealthCheckInterface
+final class SysFileReferenceLocalizedParentDeleted extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/SysFileReferenceLocalizedParentExists.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedParentExists.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Localized sys_file_reference records must point to a sys_language_uid=0 parent that exists.
  */
-class SysFileReferenceLocalizedParentExists extends AbstractHealthCheck implements HealthCheckInterface
+final class SysFileReferenceLocalizedParentExists extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/TcaTablesDeleteFlagZeroOrOne.php
+++ b/Classes/HealthCheck/TcaTablesDeleteFlagZeroOrOne.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Values of delete column of TCA tables with enabled soft-delete must be either 0 or 1.
  */
-class TcaTablesDeleteFlagZeroOrOne extends AbstractHealthCheck implements HealthCheckInterface
+final class TcaTablesDeleteFlagZeroOrOne extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/TcaTablesInvalidLanguageParent.php
+++ b/Classes/HealthCheck/TcaTablesInvalidLanguageParent.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Check if translated records point to existing records.
  */
-class TcaTablesInvalidLanguageParent extends AbstractHealthCheck implements HealthCheckInterface
+final class TcaTablesInvalidLanguageParent extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/TcaTablesPidDeleted.php
+++ b/Classes/HealthCheck/TcaTablesPidDeleted.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Not-deleted TCA records must point to not-deleted pages
  */
-class TcaTablesPidDeleted extends AbstractHealthCheck implements HealthCheckInterface
+final class TcaTablesPidDeleted extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/TcaTablesPidMissing.php
+++ b/Classes/HealthCheck/TcaTablesPidMissing.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * All TCA records must point to existing pages
  */
-class TcaTablesPidMissing extends AbstractHealthCheck implements HealthCheckInterface
+final class TcaTablesPidMissing extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDeleted.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDeleted.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Tables with not-deleted record translations must point to not-deleted records in transOrigPointerField
  */
-class TcaTablesTranslatedLanguageParentDeleted extends AbstractHealthCheck implements HealthCheckInterface
+final class TcaTablesTranslatedLanguageParentDeleted extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPid.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPid.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Tables with record translations must have their pid set to the same pid the default language record points to.
  */
-class TcaTablesTranslatedLanguageParentDifferentPid extends AbstractHealthCheck implements HealthCheckInterface
+final class TcaTablesTranslatedLanguageParentDifferentPid extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentMissing.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentMissing.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Tables with record translations must point to existing records in transOrigPointerField
  */
-class TcaTablesTranslatedLanguageParentMissing extends AbstractHealthCheck implements HealthCheckInterface
+final class TcaTablesTranslatedLanguageParentMissing extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/TcaTablesTranslatedParentInvalidPointer.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedParentInvalidPointer.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Records in localization tables must point to a sys_language_uid=0 record in their transOrigPointerField.
  */
-class TcaTablesTranslatedParentInvalidPointer extends AbstractHealthCheck implements HealthCheckInterface
+final class TcaTablesTranslatedParentInvalidPointer extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/WorkspacesNotLoadedRecordsDangling.php
+++ b/Classes/HealthCheck/WorkspacesNotLoadedRecordsDangling.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
  *
  * This check detects and deletes all records having t3ver_wsid != 0 when ext:workspaces is not loaded.
  */
-class WorkspacesNotLoadedRecordsDangling extends AbstractHealthCheck implements HealthCheckInterface
+final class WorkspacesNotLoadedRecordsDangling extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/WorkspacesRecordsOfDeletedWorkspaces.php
+++ b/Classes/HealthCheck/WorkspacesRecordsOfDeletedWorkspaces.php
@@ -30,7 +30,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * This class looks for workspace records in all tables which may have been missed.
  */
-class WorkspacesRecordsOfDeletedWorkspaces extends AbstractHealthCheck implements HealthCheckInterface
+final class WorkspacesRecordsOfDeletedWorkspaces extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthCheck/WorkspacesSoftDeletedRecords.php
+++ b/Classes/HealthCheck/WorkspacesSoftDeletedRecords.php
@@ -24,7 +24,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
  * Workspace records (t3ver_wsid != 0) are NOT soft-delete aware. Find
  * all deleted=1 workspace records and delete them.
  */
-class WorkspacesSoftDeletedRecords extends AbstractHealthCheck implements HealthCheckInterface
+final class WorkspacesSoftDeletedRecords extends AbstractHealthCheck implements HealthCheckInterface
 {
     public function header(SymfonyStyle $io): void
     {

--- a/Classes/HealthFactory/HealthFactory.php
+++ b/Classes/HealthFactory/HealthFactory.php
@@ -20,7 +20,7 @@ namespace Lolli\Dbdoctor\HealthFactory;
 use Lolli\Dbdoctor\HealthCheck;
 use Psr\Container\ContainerInterface;
 
-class HealthFactory implements HealthFactoryInterface
+final class HealthFactory implements HealthFactoryInterface
 {
     /**
      * @var string[]

--- a/Classes/Helper/PagesRootlineHelper.php
+++ b/Classes/Helper/PagesRootlineHelper.php
@@ -20,7 +20,7 @@ namespace Lolli\Dbdoctor\Helper;
 use Lolli\Dbdoctor\Exception\NoSuchPageException;
 use Lolli\Dbdoctor\Exception\NoSuchRecordException;
 
-class PagesRootlineHelper
+final class PagesRootlineHelper
 {
     /**
      * @var array<int, array<string, int|string|bool>>

--- a/Classes/Helper/RecordsHelper.php
+++ b/Classes/Helper/RecordsHelper.php
@@ -24,7 +24,7 @@ use Lolli\Dbdoctor\Exception\UnexpectedNumberOfAffectedRowsException;
 use Psr\Container\ContainerInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
-class RecordsHelper
+final class RecordsHelper
 {
     /**
      * @var array<string, array{string, sqlString: string, statement: Statement}>

--- a/Classes/Helper/TableHelper.php
+++ b/Classes/Helper/TableHelper.php
@@ -19,7 +19,7 @@ namespace Lolli\Dbdoctor\Helper;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
-class TableHelper
+final class TableHelper
 {
     /**
      * @var array<string, bool>

--- a/Classes/Helper/TcaHelper.php
+++ b/Classes/Helper/TcaHelper.php
@@ -22,7 +22,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Stateless helper service for various TCA details.
  */
-class TcaHelper
+final class TcaHelper
 {
     /**
      * @return iterable<string>

--- a/Classes/Renderer/AffectedPagesRenderer.php
+++ b/Classes/Renderer/AffectedPagesRenderer.php
@@ -19,7 +19,7 @@ namespace Lolli\Dbdoctor\Renderer;
 
 use Lolli\Dbdoctor\Helper\PagesRootlineHelper;
 
-class AffectedPagesRenderer
+final class AffectedPagesRenderer
 {
     private PagesRootlineHelper $pagesRootlineHelper;
 

--- a/Classes/Renderer/RecordsRenderer.php
+++ b/Classes/Renderer/RecordsRenderer.php
@@ -22,7 +22,7 @@ use Lolli\Dbdoctor\Helper\RecordsHelper;
 use Lolli\Dbdoctor\Helper\TableHelper;
 use Lolli\Dbdoctor\Helper\TcaHelper;
 
-class RecordsRenderer
+final class RecordsRenderer
 {
     /**
      * @var array<int, string>


### PR DESCRIPTION
Make most classes final, have final keyword
in abstracts if methods are not meant to be
inherited. This makes a lot of scoping more
clear, and third party extensions should never
'xclass' details anyways, but should send patches
or have composer based patches if really needed.