### PR TITLE
[TASK] Improve output and wording

### DIFF
--- a/Classes/HealthCheck/AbstractHealthCheck.php
+++ b/Classes/HealthCheck/AbstractHealthCheck.php
@@ -31,6 +31,15 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
  */
 abstract class AbstractHealthCheck
 {
+    // Used in IO when a check may DELETE records
+    protected const TAG_REMOVE = 'remove';
+    // Used in IO when a check may "deleted=1" records
+    protected const TAG_SOFT_DELETE = 'soft-delete';
+    // Used in IO when a check may DELETE workspace records
+    protected const TAG_WORKSPACE_REMOVE = 'workspace-remove';
+    // Used in IO when a check may UPDATE single fields of records
+    protected const TAG_UPDATE = 'update-fields';
+
     /**
      * Set to an absolute, not-empty file path string when sql command should be logged.
      */
@@ -410,6 +419,18 @@ abstract class AbstractHealthCheck
                 $io->warning('Deleted "' . $deleteCount . '" records from "' . $tableName . '" table');
             }
         }
+    }
+
+    /**
+     * Helper method for header() to render a list of tags
+     * to declare the type of changes this check applies.
+     *
+     * @param string ...$tags
+     */
+    protected function outputTags(SymfonyStyle $io, ...$tags): void
+    {
+        $tags = array_map(fn (string $tag): string => '<comment>' . $tag . '</comment>', $tags);
+        $io->text('Actions: ' . implode(', ', $tags));
     }
 
     private function logAndOutputSql(SymfonyStyle $io, bool $simulate, string $sql): void

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentDeleted.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentDeleted.php
@@ -32,11 +32,12 @@ final class InlineForeignFieldChildrenParentDeleted extends AbstractHealthCheck 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for inline foreign field records with deleted=1 parent');
+        $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_REMOVE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
-            '[UPDATE] TCA inline foreign field records point to a parent record. When this parent is',
-            '         soft-deleted (deleted=1), the child should be soft-deleted, too.',
-            '         This check finds affected children and sets them deleted=1 for live records,',
-            '         or removes them when dealing with workspace records.',
+            'TCA inline foreign field records point to a parent record. When this parent is',
+            'soft-deleted, all children must be soft-deleted, too.',
+            'This check finds not soft-deleted children and sets soft-deleted for for live records,',
+            'or removes them when dealing with workspace records.',
         ]);
     }
 

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferent.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferent.php
@@ -30,10 +30,11 @@ final class InlineForeignFieldChildrenParentLanguageDifferent extends AbstractHe
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for inline foreign field records with different language than their parent');
+        $this->outputTags($io, self::TAG_UPDATE);
         $io->text([
-            '[UPDATE] TCA inline foreign field child records point to a parent record. This check finds',
-            '         child records that have a different language than the parent record.',
-            '         Affected child records are updated by setting them to the same language as the parent record.',
+            'TCA inline foreign field child records point to a parent record. This check finds',
+            'child records that have a different language than the parent record.',
+            'Affected children are updated by setting them to the same language as the parent record.',
         ]);
     }
 

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentMissing.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentMissing.php
@@ -30,9 +30,10 @@ final class InlineForeignFieldChildrenParentMissing extends AbstractHealthCheck 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for inline foreign field records with missing parent');
+        $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
-            '[DELETE] TCA inline foreign field records point to a parent record. This parent must exist.',
-            '         Inline children with missing parent should be deleted.',
+            'TCA inline foreign field records point to a parent record. This parent',
+            'must exist. Inline children with missing parent ale deleted.',
         ]);
     }
 

--- a/Classes/HealthCheck/PagesBrokenTree.php
+++ b/Classes/HealthCheck/PagesBrokenTree.php
@@ -28,10 +28,11 @@ final class PagesBrokenTree extends AbstractHealthCheck implements HealthCheckIn
     public function header(SymfonyStyle $io): void
     {
         $io->section('Check page tree integrity');
+        $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
-            '[DELETE] This health check finds "pages" records with their "pid" set to pages that do',
-            '         not exist in the database. Pages without proper connection to the tree root are never',
-            '         shown in the backend. They should be deleted.',
+            'This health check finds "pages" records with their "pid" set to pages that do',
+            'not exist in the database. Pages without proper connection to the tree root are never',
+            'shown in the backend. They are removed.',
         ]);
     }
 

--- a/Classes/HealthCheck/PagesTranslatedLanguageParentDeleted.php
+++ b/Classes/HealthCheck/PagesTranslatedLanguageParentDeleted.php
@@ -31,11 +31,12 @@ final class PagesTranslatedLanguageParentDeleted extends AbstractHealthCheck imp
     public function header(SymfonyStyle $io): void
     {
         $io->section('Check pages with deleted language parent');
+        $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
-            '[UPDATE] This health check finds translated and not deleted "pages" records (sys_language_uid > 0)',
-            '         with their default language record (l10n_parent field) set to deleted.',
-            '         Those translated pages are never shown in backend and frontend. They are set to deleted in',
-            '         live and removed from database if they are workspace overlay records.',
+            'This health check finds not deleted but translated (sys_language_uid > 0) "pages" records,',
+            'with their default language record (l10n_parent field) being soft-deleted.',
+            'Those translated pages are never shown in backend and frontend. They are soft-deleted in',
+            'live and removed if they are workspace overlay records.',
         ]);
     }
 

--- a/Classes/HealthCheck/PagesTranslatedLanguageParentDifferentPid.php
+++ b/Classes/HealthCheck/PagesTranslatedLanguageParentDifferentPid.php
@@ -29,10 +29,11 @@ final class PagesTranslatedLanguageParentDifferentPid extends AbstractHealthChec
     public function header(SymfonyStyle $io): void
     {
         $io->section('Check pages with different pid than their language parent');
+        $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
-            '[DELETE] This health check finds translated "pages" records (sys_language_uid > 0) with',
-            '         their default language record (l10n_parent field) on a different pid.',
-            '         Those translated pages are shown in backend at a wrong place. They will be deleted.',
+            'This health check finds translated "pages" records (sys_language_uid > 0) with',
+            'their default language record (l10n_parent field) on a different pid.',
+            'Those translated pages are shown in backend at a wrong place. They are removed.',
         ]);
     }
 

--- a/Classes/HealthCheck/PagesTranslatedLanguageParentMissing.php
+++ b/Classes/HealthCheck/PagesTranslatedLanguageParentMissing.php
@@ -29,10 +29,11 @@ final class PagesTranslatedLanguageParentMissing extends AbstractHealthCheck imp
     public function header(SymfonyStyle $io): void
     {
         $io->section('Check pages with missing language parent');
+        $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
-            '[DELETE] This health check finds translated "pages" records (sys_language_uid > 0) with',
-            '         their default language record (l10n_parent field) not existing in the database.',
-            '         Those translated pages are never shown in backend and frontend and should be deleted.',
+            'This health check finds translated "pages" records (sys_language_uid > 0) with',
+            'their default language record (l10n_parent field) not existing in the database.',
+            'Those translated pages are never shown in backend and frontend and removed.',
         ]);
     }
 

--- a/Classes/HealthCheck/SysFileReferenceDangling.php
+++ b/Classes/HealthCheck/SysFileReferenceDangling.php
@@ -30,10 +30,10 @@ final class SysFileReferenceDangling extends AbstractHealthCheck implements Heal
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for orphan sys_file_reference records');
+        $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
-            '[DELETE] A basic check for sys_file_reference: the records referenced in uid_local',
-            '         and uid_foreign must exist, otherwise that sys_file_reference row is obsolete and',
-            '         should be removed.',
+            'Basic check of sys_file_reference: Records referenced in uid_local and uid_foreign',
+            'must exist, otherwise that sys_file_reference row is obsolete and removed.',
         ]);
     }
 

--- a/Classes/HealthCheck/SysFileReferenceInvalidPid.php
+++ b/Classes/HealthCheck/SysFileReferenceInvalidPid.php
@@ -30,10 +30,11 @@ final class SysFileReferenceInvalidPid extends AbstractHealthCheck implements He
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for sys_file_reference records with invalid pid');
+        $this->outputTags($io, self::TAG_UPDATE);
         $io->text([
-            '[UPDATE] Records in "sys_file_reference" must have "pid" set to the same pid as the',
-            '         parent record: If for instance a tt_content record on pid 5 references a sys_file, the',
-            '         sys_file_reference record should be on pid 5, too. This check takes care of this.',
+            'Records in "sys_file_reference" must have "pid" set to the same pid as the',
+            'parent record: If for instance a tt_content record on pid 5 references a sys_file, the',
+            'sys_file_reference record should be on pid 5, too. This updates the pid of affected records.',
         ]);
     }
 

--- a/Classes/HealthCheck/SysFileReferenceInvalidTableLocal.php
+++ b/Classes/HealthCheck/SysFileReferenceInvalidTableLocal.php
@@ -32,12 +32,13 @@ final class SysFileReferenceInvalidTableLocal extends AbstractHealthCheck implem
         $io->section('Scan for sys_file_reference_records with broken table_local field');
         if ((new Typo3Version())->getMajorVersion() >= 12) {
             $io->text([
-                '[SKIPPED] This check is obsolete with core v12.',
+                'This check is obsolete with core v12.',
             ]);
         } else {
+            $this->outputTags($io, self::TAG_UPDATE);
             $io->text([
-                '[UPDATE] Records in "sys_file_reference" must have field "table_local" set to',
-                '         "sys_file". This check verifies this and can update non-compliant rows.',
+                'Records in "sys_file_reference" must have field "table_local" set to',
+                '"sys_file". This check verifies this and can update- non-compliant rows.',
             ]);
         }
     }

--- a/Classes/HealthCheck/SysFileReferenceLocalizedFieldSync.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedFieldSync.php
@@ -32,14 +32,15 @@ final class SysFileReferenceLocalizedFieldSync extends AbstractHealthCheck imple
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for localized sys_file_reference records with parent not in sync');
+        $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
-            '[UPDATE] Localized records in "sys_file_reference" (sys_language_uid > 0) must have fields "tablenames"',
-            '         and "fieldname" set to the same values as its language parent record.',
-            '         Records violating this indicate something is wrong with this localized record.',
-            '         This may happen for instance, when the ctype of a default language record is changed and',
-            '         relations are adapted after the record has been localized. Check findings manually if in doubt!',
-            '         For now, affected localized records are set to deleted=1 in live and removed from table if',
-            '         they are workspace overlay records.',
+            'Localized records in "sys_file_reference" (sys_language_uid > 0) must have fields "tablenames"',
+            'and "fieldname" set to the same values as its language parent record.',
+            'Records violating this indicate something is wrong with this localized record.',
+            'This may happen for instance, when the tt_content ctype of a default language record is changed and',
+            'relations are adapted after the record has been localized. Verify findings manually!',
+            'This check sets affected localized records are set to deleted=1 in live and removes the',
+            'if they are workspace overlay records.',
         ]);
     }
 

--- a/Classes/HealthCheck/SysFileReferenceLocalizedParentDeleted.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedParentDeleted.php
@@ -32,10 +32,11 @@ final class SysFileReferenceLocalizedParentDeleted extends AbstractHealthCheck i
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for localized sys_file_reference records with deleted parent');
+        $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
-            '[UPDATE] Localized, not deleted records in "sys_file_reference" (sys_language_uid > 0) having',
-            '         l10n_parent > 0 must point to a sys_language_uid = 0, not deleted, language parent record.',
-            '         Records violating this are soft-deleted in live and removed if in workspaces.',
+            'Localized, not deleted records in "sys_file_reference" (sys_language_uid > 0) having',
+            'l10n_parent > 0 must point to a sys_language_uid = 0, not deleted, language parent record.',
+            'Records violating this are soft-deleted in live and removed if in workspaces.',
         ]);
     }
 

--- a/Classes/HealthCheck/SysFileReferenceLocalizedParentExists.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedParentExists.php
@@ -30,10 +30,11 @@ final class SysFileReferenceLocalizedParentExists extends AbstractHealthCheck im
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for localized sys_file_reference records without parent');
+        $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
-            '[DELETE] Localized records in "sys_file_reference" (sys_language_uid > 0) having',
-            '         l10n_parent > 0 must point to a sys_language_uid = 0, existing language parent record.',
-            '         Records violating this are removed.',
+            'Localized records in "sys_file_reference" (sys_language_uid > 0) having',
+            'l10n_parent > 0 must point to a sys_language_uid = 0 and existing language parent record.',
+            'Records violating this are removed.',
         ]);
     }
 

--- a/Classes/HealthCheck/TcaTablesDeleteFlagZeroOrOne.php
+++ b/Classes/HealthCheck/TcaTablesDeleteFlagZeroOrOne.php
@@ -27,11 +27,12 @@ final class TcaTablesDeleteFlagZeroOrOne extends AbstractHealthCheck implements 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for rows with delete field not "0" or "1"');
+        $this->outputTags($io, self::TAG_SOFT_DELETE);
         $io->text([
-            '[UPDATE] Values of the "deleted" column of TCA tables with enabled soft-delete',
-            '         (["ctrl"]["delete"] set to a column name) must be either zero (0) or one (1).',
-            '         The default core database DeletedRestriction tests for equality with zero.',
-            '         This scan finds records having a different value than zero or one and sets them to one.',
+            'Values of the "deleted" column of TCA tables with enabled soft-delete',
+            '(["ctrl"]["delete"] set to a column name) must be either zero (0) or one (1).',
+            'The default core database DeletedRestriction tests for equality with zero.',
+            'This scan finds records having a different value than zero or one and sets them to one.',
         ]);
     }
 

--- a/Classes/HealthCheck/TcaTablesPidMissing.php
+++ b/Classes/HealthCheck/TcaTablesPidMissing.php
@@ -29,9 +29,10 @@ final class TcaTablesPidMissing extends AbstractHealthCheck implements HealthChe
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for records on not existing pages');
+        $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
-            '[DELETE] TCA records have a pid field set to a single page. This page must exist.',
-            '         Records on pages that do not exist anymore should be deleted.',
+            'TCA records have a pid field set to a single page. This page must exist.',
+            'Records on pages that do not exist anymore are deleted.',
         ]);
     }
 

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDeleted.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDeleted.php
@@ -31,11 +31,12 @@ final class TcaTablesTranslatedLanguageParentDeleted extends AbstractHealthCheck
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for not-deleted record translations with deleted parent');
+        $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
-            '[UPDATE] Record translations use the TCA ctrl field "transOrigPointerField"',
-            '         (DB field name usually "l10n_parent" or "l18n_parent"). This field points to a',
-            '         default language record. This health check verifies that target is not deleted=1 in the database.',
-            '         Affected records are set to deleted=1 if in live, or removed if in workspaces.',
+            'Record translations use the TCA ctrl field "transOrigPointerField"',
+            '(DB field name usually "l10n_parent" or "l18n_parent"). This field points to a',
+            'default language record. This health check verifies the target is not deleted=1.',
+            'Affected records are set to deleted=1 if in live, or removed if in workspaces.',
         ]);
     }
 

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPid.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPid.php
@@ -31,12 +31,13 @@ final class TcaTablesTranslatedLanguageParentDifferentPid extends AbstractHealth
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for record translations on wrong pid');
+        $this->outputTags($io, self::TAG_UPDATE, self::TAG_SOFT_DELETE, self::TAG_REMOVE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
-            '[UPDATE] Record translations use the TCA ctrl field "transOrigPointerField"',
-            '         (DB field name usually "l10n_parent" or "l18n_parent"). This field points to a',
-            '         default language record. This health check verifies translated records are on',
-            '         the same pid as the default language record. It will move, hide or delete affected',
-            '         records, which depends on potentially existing localizations on the target page.',
+            'Record translations use the TCA ctrl field "transOrigPointerField"',
+            '(DB field name usually "l10n_parent" or "l18n_parent"). This field points to a',
+            'default language record. This health check verifies translated records are on',
+            'the same pid as the default language record. It will move, hide or remove affected',
+            'records, which depends on potentially existing localizations on the target page.',
         ]);
     }
 

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentMissing.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentMissing.php
@@ -29,11 +29,12 @@ final class TcaTablesTranslatedLanguageParentMissing extends AbstractHealthCheck
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for record translations with missing parent');
+        $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
-            '[DELETE] Record translations use the TCA ctrl field "transOrigPointerField"',
-            '         (DB field name usually "l10n_parent" or "l18n_parent"). This field points to a',
-            '         default language record. This health check verifies if that target exists in the database.',
-            '         Affected records without language parent are removed.',
+            'Record translations use the TCA ctrl field "transOrigPointerField"',
+            '(DB field name usually "l10n_parent" or "l18n_parent"). This field points to a',
+            'default language record. This health check verifies if that target exists.',
+            'Affected records without language parent are removed.',
         ]);
     }
 

--- a/Classes/HealthCheck/TcaTablesTranslatedParentInvalidPointer.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedParentInvalidPointer.php
@@ -31,12 +31,13 @@ final class TcaTablesTranslatedParentInvalidPointer extends AbstractHealthCheck 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for record translations pointing to non default language parent');
+        $this->outputTags($io, self::TAG_UPDATE);
         $io->text([
-            '[UPDATE] Record translations ("translate" / "connected" mode, as opposed to "free" mode) use the',
-            '         database field "transOrigPointerField" (DB field name usually "l10n_parent" or "l18n_parent").',
-            '         This field points to the default language record if set. This health check verifies if that target',
-            '         actually has sys_language_uid = 0. Violating localizations are set to the transOrigPointerField',
-            '         of the current target record.',
+            'Record translations ("translate" / "connected" mode, as opposed to "free" mode) use the',
+            'database field "transOrigPointerField" (field name usually "l10n_parent" or "l18n_parent").',
+            'This field points to the default language record. This health check verifies that target',
+            'actually has sys_language_uid = 0. Violating localizations are set to the transOrigPointerField',
+            'of the current target record.',
         ]);
     }
 

--- a/Classes/HealthCheck/WorkspacesNotLoadedRecordsDangling.php
+++ b/Classes/HealthCheck/WorkspacesNotLoadedRecordsDangling.php
@@ -32,12 +32,13 @@ final class WorkspacesNotLoadedRecordsDangling extends AbstractHealthCheck imple
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for workspace records when ext:workspaces is not loaded');
+        $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
-            '[DELETE] When extension "workspaces" is not loaded, there should be no workspace overlay',
-            '         records (t3ver_wsid != 0). This check deletes all workspace related records if',
-            '         the extension is not loaded. Think about this twice: If workspaces is a thing',
-            '         in your instance, the extension must be loaded, otherwise this check will',
-            '         remove all existing workspace overlay records!',
+            'When extension "workspaces" is not loaded, there should be no workspace overlay',
+            'records (t3ver_wsid != 0). This check removes all workspace related records if',
+            'the extension is not loaded. Think about this twice: If workspaces is a thing',
+            'in your instance, the extension must be loaded, otherwise this check will',
+            'remove all existing workspace overlay records!',
         ]);
     }
 

--- a/Classes/HealthCheck/WorkspacesRecordsOfDeletedWorkspaces.php
+++ b/Classes/HealthCheck/WorkspacesRecordsOfDeletedWorkspaces.php
@@ -35,11 +35,12 @@ final class WorkspacesRecordsOfDeletedWorkspaces extends AbstractHealthCheck imp
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for workspace records of deleted sys_workspace\'s');
+        $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
-            '[DELETE] When a workspace (table "sys_workspace") is deleted, all existing workspace',
-            '         overlays in all tables of this workspace are discarded (= removed from DB). When this',
-            '         goes wrong, or if the workspace extension is removed, the system ends up with "dangling"',
-            '         workspace records in tables. This health check finds those records and removes them.',
+            'When a workspace (table "sys_workspace") is deleted, all existing workspace',
+            'overlays in all tables of this workspace are removed. When this goes wrong,',
+            'or if the workspace extension is removed, the system ends up with "dangling"',
+            'workspace records in tables. This health check finds those records and removes them.',
         ]);
     }
 

--- a/Classes/HealthCheck/WorkspacesSoftDeletedRecords.php
+++ b/Classes/HealthCheck/WorkspacesSoftDeletedRecords.php
@@ -29,10 +29,11 @@ final class WorkspacesSoftDeletedRecords extends AbstractHealthCheck implements 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for soft-deleted workspaces records');
+        $this->outputTags($io, self::TAG_WORKSPACE_REMOVE);
         $io->text([
-            '[DELETE] Records in workspaces (t3ver_wsid != 0) are not soft-delete aware since TYPO3 v11:',
-            '         When "discarding" workspace changes, affected records are fully removed from the database.',
-            '         This check looks for "t3ver_wsid != 0" having "deleted = 1" and deletes them from the table.',
+            'Records in workspaces (t3ver_wsid != 0) are not soft-delete aware since TYPO3 v11:',
+            'When "discarding" workspace changes, affected records are fully removed from the database.',
+            'This check looks for workspace overlays being soft-deleted and removes them.',
         ]);
     }
 

--- a/Classes/HealthFactory/HealthFactory.php
+++ b/Classes/HealthFactory/HealthFactory.php
@@ -45,11 +45,10 @@ final class HealthFactory implements HealthFactoryInterface
         HealthCheck\SysFileReferenceInvalidPid::class,
         HealthCheck\TcaTablesPidMissing::class,
         // @todo: Disabled for now, see the class comment
-        // HealthCheck\SysFileReferenceInvalidFieldname::class,
+        // SysFileReferenceInvalidFieldname::class,
         HealthCheck\TcaTablesPidDeleted::class,
         HealthCheck\TcaTablesTranslatedLanguageParentMissing::class,
-        // Check sys_file_reference pointing to not existing records *again*:
-        // TcaTablesTranslatedLanguageParentMissing may have deleted some.
+        // Check sys_file_reference pointing to not existing records *again*, TcaTablesTranslatedLanguageParentMissing may have deleted some.
         HealthCheck\SysFileReferenceDangling::class,
         HealthCheck\TcaTablesTranslatedLanguageParentDeleted::class,
         HealthCheck\TcaTablesTranslatedLanguageParentDifferentPid::class,


### PR DESCRIPTION
Single checks now output general "tags"
to declare their possible changes.
The imprecise [DELETE] and [UPDATE]
declaration is removed in favor of
these tags.