### PR TITLE
[FEATURE] sys_language_uid <= 0 rows have l10n_source=0

### DIFF
--- a/Classes/HealthFactory/HealthFactory.php
+++ b/Classes/HealthFactory/HealthFactory.php
@@ -37,6 +37,7 @@ final class HealthFactory implements HealthFactoryInterface
         // Note we have "move sys_redirects" *before* PagesBrokenTree for a better chance to move to correct pid
         HealthCheck\SysRedirectInvalidPid::class,
         HealthCheck\TcaTablesLanguageLessThanOneHasZeroLanguageParent::class,
+        HealthCheck\TcaTablesLanguageLessThanOneHasZeroLanguageSource::class,
         HealthCheck\PagesBrokenTree::class,
         HealthCheck\PagesTranslatedLanguageParentMissing::class,
         HealthCheck\PagesTranslatedLanguageParentDeleted::class,

--- a/Classes/Helper/TcaHelper.php
+++ b/Classes/Helper/TcaHelper.php
@@ -70,7 +70,7 @@ final class TcaHelper
     }
 
     /**
-     * Note we check for *both* languageField (usually sys_language_uid)
+     * We check for *both* languageField (usually sys_language_uid)
      * and transOrigPointerField (usually l10n_parent) here: Only having
      * languageField does not make too much sense and is more a TCA bug
      * than anything else and not handled.
@@ -84,6 +84,30 @@ final class TcaHelper
         foreach ($GLOBALS['TCA'] as $tableName => $config) {
             if (($config['ctrl']['languageField'] ?? false)
                 && ($config['ctrl']['transOrigPointerField'] ?? false)
+                && !in_array($tableName, $ignoreTables, true)
+            ) {
+                yield $tableName;
+            }
+        }
+    }
+
+    /**
+     * We check for languageField (usually sys_language_uid)
+     * *and* transOrigPointerField (usually l10n_parent) *and*
+     * translationSource (usually l10n_source) here: Not having
+     * all three of them does not make too much sense and is more a TCA bug
+     * than anything else and not handled.
+     *
+     * @param array<int, string> $ignoreTables
+     * @return iterable<string>
+     */
+    public function getNextLanguageSourceAwareTcaTable(array $ignoreTables = []): iterable
+    {
+        $this->verifyTcaIsArray();
+        foreach ($GLOBALS['TCA'] as $tableName => $config) {
+            if (($config['ctrl']['languageField'] ?? false)
+                && ($config['ctrl']['transOrigPointerField'] ?? false)
+                && ($config['ctrl']['translationSource'] ?? false)
                 && !in_array($tableName, $ignoreTables, true)
             ) {
                 yield $tableName;
@@ -183,6 +207,11 @@ final class TcaHelper
     public function getTranslationParentField(string $tableName): ?string
     {
         return ($GLOBALS['TCA'][$tableName]['ctrl']['transOrigPointerField'] ?? null) ?: null;
+    }
+
+    public function getTranslationSourceField(string $tableName): ?string
+    {
+        return ($GLOBALS['TCA'][$tableName]['ctrl']['translationSource'] ?? null) ?: null;
     }
 
     /**

--- a/Tests/Unit/Helper/TcaHelperTest.php
+++ b/Tests/Unit/Helper/TcaHelperTest.php
@@ -281,6 +281,105 @@ class TcaHelperTest extends UnitTestCase
     /**
      * @test
      */
+    public function getNextLanguageSourceAwareTcaTableThrowsExceptionIfTcaIsNotAnArray(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1688203176);
+        $GLOBALS['TCA'] = null;
+        $subject = new TcaHelper();
+        foreach ($subject->getNextLanguageSourceAwareTcaTable() as $item) {
+            // Trigger iterable
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function getNextLanguageSourceAwareTcaTableReturnsLanguageSourceAwareEnabledTcaTables(): void
+    {
+        $GLOBALS['TCA'] = [
+            'languageAware1' => [
+                'ctrl' => [
+                    'languageField' => 'sys_language_uid',
+                    'transOrigPointerField' => 'l18n_parent',
+                    'translationSource' => 'l10n_source',
+                ],
+            ],
+            'notAware1' => [
+                'ctrl' => [],
+            ],
+            'notAware2' => [
+                'ctrl' => [
+                    'languageField' => 'sys_language_uid',
+                ],
+            ],
+            'notAware3' => [
+                'ctrl' => [
+                    'transOrigPointerField' => 'l18n_parent',
+                ],
+            ],
+            'notAware4' => [
+                'ctrl' => [
+                    'languageField' => 'sys_language_uid',
+                    'transOrigPointerField' => 'l18n_parent',
+                ],
+            ],
+            'notAware5' => [
+                'ctrl' => [
+                    'transOrigPointerField' => 'l18n_parent',
+                    'translationSource' => 'l10n_source',
+                ],
+            ],
+            'notAware6' => [
+                'ctrl' => [
+                    'languageField' => 'sys_language_uid',
+                    'translationSource' => 'l10n_source',
+                ],
+            ],
+        ];
+        $subject = new TcaHelper();
+        $result = [];
+        foreach ($subject->getNextLanguageSourceAwareTcaTable() as $table) {
+            $result[] = $table;
+        }
+        $expected = [
+            'languageAware1',
+        ];
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getNextLanguageSourceAwareTcaTableIgnoresTable(): void
+    {
+        $GLOBALS['TCA'] = [
+            'foo' => [
+                'ctrl' => [
+                    'languageField' => 'sys_language_uid',
+                    'transOrigPointerField' => 'l18n_parent',
+                    'translationSource' => 'l10n_source',
+                ],
+            ],
+            'bar' => [
+                'ctrl' => [
+                    'languageField' => 'sys_language_uid',
+                    'transOrigPointerField' => 'l18n_parent',
+                    'translationSource' => 'l10n_source',
+                ],
+            ],
+        ];
+        $subject = new TcaHelper();
+        $tables = [];
+        foreach ($subject->getNextLanguageSourceAwareTcaTable(['foo']) as $item) {
+            $tables[] = $item;
+        }
+        self::assertSame(['bar'], $tables);
+    }
+
+    /**
+     * @test
+     */
     public function getNextInlineForeignFieldChildTcaTableThrowsExceptionIfTcaIsNotAnArray(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -866,6 +965,23 @@ class TcaHelperTest extends UnitTestCase
     public function getTranslationParentFieldReturnsNull(): void
     {
         self::assertNull((new TcaHelper())->getTranslationParentField('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function getTranslationSourceFieldReturnsField(): void
+    {
+        $GLOBALS['TCA']['foo']['ctrl']['translationSource'] = 'l10n_parent';
+        self::assertSame('l10n_parent', (new TcaHelper())->getTranslationSourceField('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function getTranslationSourceFieldReturnsNull(): void
+    {
+        self::assertNull((new TcaHelper())->getTranslationSourceField('foo'));
     }
 
     /**


### PR DESCRIPTION
A first check to deal with l10n_source: Rows with
sys_language_uid = 0 or -1 must have l10n_source
set to zero. This is added pretty early to not confuse other checks.