### PR TITLE
[TASK] Output check class name on CLI

### DIFF
--- a/Classes/HealthCheck/AbstractHealthCheck.php
+++ b/Classes/HealthCheck/AbstractHealthCheck.php
@@ -31,6 +31,8 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
  */
 abstract class AbstractHealthCheck
 {
+    // Used in IO when a check is fully disabled, for instance due to TYPO3 version
+    protected const TAG_DISABLED = 'disabled';
     // Used in IO when a check may DELETE records
     protected const TAG_REMOVE = 'remove';
     // Used in IO when a check may "deleted=1" records
@@ -397,6 +399,11 @@ abstract class AbstractHealthCheck
     {
         $tags = array_map(fn (string $tag): string => '<comment>' . $tag . '</comment>', $tags);
         $io->text('Actions: ' . implode(', ', $tags));
+    }
+
+    final protected function outputClass(SymfonyStyle $io): void
+    {
+        $io->text(('Class: <comment>' . (new \ReflectionClass($this))->getShortName()) . '</comment>');
     }
 
     final protected function outputTableDeleteBefore(SymfonyStyle $io, bool $simulate, string $tableName): void

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentDeleted.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentDeleted.php
@@ -32,6 +32,7 @@ final class InlineForeignFieldChildrenParentDeleted extends AbstractHealthCheck 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for inline foreign field records with deleted=1 parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_REMOVE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'TCA inline foreign field records point to a parent record. When this parent is',

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferent.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferent.php
@@ -30,6 +30,7 @@ final class InlineForeignFieldChildrenParentLanguageDifferent extends AbstractHe
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for inline foreign field records with different language than their parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_UPDATE);
         $io->text([
             'TCA inline foreign field child records point to a parent record. This check finds',

--- a/Classes/HealthCheck/InlineForeignFieldChildrenParentMissing.php
+++ b/Classes/HealthCheck/InlineForeignFieldChildrenParentMissing.php
@@ -30,6 +30,7 @@ final class InlineForeignFieldChildrenParentMissing extends AbstractHealthCheck 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for inline foreign field records with missing parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'TCA inline foreign field records point to a parent record. This parent',

--- a/Classes/HealthCheck/PagesBrokenTree.php
+++ b/Classes/HealthCheck/PagesBrokenTree.php
@@ -28,6 +28,7 @@ final class PagesBrokenTree extends AbstractHealthCheck implements HealthCheckIn
     public function header(SymfonyStyle $io): void
     {
         $io->section('Check page tree integrity');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'This health check finds "pages" records with their "pid" set to pages that do',

--- a/Classes/HealthCheck/PagesTranslatedLanguageParentDeleted.php
+++ b/Classes/HealthCheck/PagesTranslatedLanguageParentDeleted.php
@@ -31,6 +31,7 @@ final class PagesTranslatedLanguageParentDeleted extends AbstractHealthCheck imp
     public function header(SymfonyStyle $io): void
     {
         $io->section('Check pages with deleted language parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'This health check finds not deleted but translated (sys_language_uid > 0) "pages" records,',

--- a/Classes/HealthCheck/PagesTranslatedLanguageParentDifferentPid.php
+++ b/Classes/HealthCheck/PagesTranslatedLanguageParentDifferentPid.php
@@ -29,6 +29,7 @@ final class PagesTranslatedLanguageParentDifferentPid extends AbstractHealthChec
     public function header(SymfonyStyle $io): void
     {
         $io->section('Check pages with different pid than their language parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'This health check finds translated "pages" records (sys_language_uid > 0) with',

--- a/Classes/HealthCheck/PagesTranslatedLanguageParentMissing.php
+++ b/Classes/HealthCheck/PagesTranslatedLanguageParentMissing.php
@@ -29,6 +29,7 @@ final class PagesTranslatedLanguageParentMissing extends AbstractHealthCheck imp
     public function header(SymfonyStyle $io): void
     {
         $io->section('Check pages with missing language parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'This health check finds translated "pages" records (sys_language_uid > 0) with',

--- a/Classes/HealthCheck/SysFileReferenceDangling.php
+++ b/Classes/HealthCheck/SysFileReferenceDangling.php
@@ -30,6 +30,7 @@ final class SysFileReferenceDangling extends AbstractHealthCheck implements Heal
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for orphan sys_file_reference records');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'Basic check of sys_file_reference: Records referenced in uid_local and uid_foreign',

--- a/Classes/HealthCheck/SysFileReferenceInvalidPid.php
+++ b/Classes/HealthCheck/SysFileReferenceInvalidPid.php
@@ -30,6 +30,7 @@ final class SysFileReferenceInvalidPid extends AbstractHealthCheck implements He
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for sys_file_reference records with invalid pid');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_UPDATE);
         $io->text([
             'Records in "sys_file_reference" must have "pid" set to the same pid as the',

--- a/Classes/HealthCheck/SysFileReferenceInvalidTableLocal.php
+++ b/Classes/HealthCheck/SysFileReferenceInvalidTableLocal.php
@@ -30,9 +30,11 @@ final class SysFileReferenceInvalidTableLocal extends AbstractHealthCheck implem
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for sys_file_reference_records with broken table_local field');
+        $this->outputClass($io);
         if ((new Typo3Version())->getMajorVersion() >= 12) {
+            $this->outputTags($io, self::TAG_DISABLED);
             $io->text([
-                'This check is obsolete with core v12.',
+                'This check is obsolete with TYPO3 core v12.',
             ]);
         } else {
             $this->outputTags($io, self::TAG_UPDATE);

--- a/Classes/HealthCheck/SysFileReferenceLocalizedFieldSync.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedFieldSync.php
@@ -32,6 +32,7 @@ final class SysFileReferenceLocalizedFieldSync extends AbstractHealthCheck imple
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for localized sys_file_reference records with parent not in sync');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'Localized records in "sys_file_reference" (sys_language_uid > 0) must have fields "tablenames"',

--- a/Classes/HealthCheck/SysFileReferenceLocalizedParentDeleted.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedParentDeleted.php
@@ -32,6 +32,7 @@ final class SysFileReferenceLocalizedParentDeleted extends AbstractHealthCheck i
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for localized sys_file_reference records with deleted parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'Localized, not deleted records in "sys_file_reference" (sys_language_uid > 0) having',

--- a/Classes/HealthCheck/SysFileReferenceLocalizedParentExists.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedParentExists.php
@@ -30,6 +30,7 @@ final class SysFileReferenceLocalizedParentExists extends AbstractHealthCheck im
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for localized sys_file_reference records without parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'Localized records in "sys_file_reference" (sys_language_uid > 0) having',

--- a/Classes/HealthCheck/SysRedirectInvalidPid.php
+++ b/Classes/HealthCheck/SysRedirectInvalidPid.php
@@ -46,6 +46,7 @@ final class SysRedirectInvalidPid extends AbstractHealthCheck implements HealthC
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for sys_redirect records on wrong pid');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_UPDATE);
         $io->text([
             'Redirect records should be located on pages having a site config, or pid 0.',

--- a/Classes/HealthCheck/TcaTablesDeleteFlagZeroOrOne.php
+++ b/Classes/HealthCheck/TcaTablesDeleteFlagZeroOrOne.php
@@ -27,6 +27,7 @@ final class TcaTablesDeleteFlagZeroOrOne extends AbstractHealthCheck implements 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for rows with delete field not "0" or "1"');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_SOFT_DELETE);
         $io->text([
             'Values of the "deleted" column of TCA tables with enabled soft-delete',

--- a/Classes/HealthCheck/TcaTablesInvalidLanguageParent.php
+++ b/Classes/HealthCheck/TcaTablesInvalidLanguageParent.php
@@ -25,6 +25,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Check if translated records point to existing records.
+ *
+ * @todo: Currently disabled!
  */
 final class TcaTablesInvalidLanguageParent extends AbstractHealthCheck implements HealthCheckInterface
 {

--- a/Classes/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageParent.php
+++ b/Classes/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageParent.php
@@ -27,6 +27,7 @@ final class TcaTablesLanguageLessThanOneHasZeroLanguageParent extends AbstractHe
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for records in default language not having language parent zero');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_UPDATE);
         $io->text([
             'TCA records in default or "all" language (typically sys_language_uid field having 0 or -1)',

--- a/Classes/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageSource.php
+++ b/Classes/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageSource.php
@@ -27,6 +27,7 @@ final class TcaTablesLanguageLessThanOneHasZeroLanguageSource extends AbstractHe
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for records in default language not having language source zero');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_UPDATE);
         $io->text([
             'TCA records in default or "all" language (typically sys_language_uid field having 0 or -1)',

--- a/Classes/HealthCheck/TcaTablesPidDeleted.php
+++ b/Classes/HealthCheck/TcaTablesPidDeleted.php
@@ -31,6 +31,7 @@ final class TcaTablesPidDeleted extends AbstractHealthCheck implements HealthChe
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for not-deleted records on pages set to deleted');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_REMOVE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'TCA records have a pid field set to a single page. This page must exist.',

--- a/Classes/HealthCheck/TcaTablesPidMissing.php
+++ b/Classes/HealthCheck/TcaTablesPidMissing.php
@@ -29,6 +29,7 @@ final class TcaTablesPidMissing extends AbstractHealthCheck implements HealthChe
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for records on not existing pages');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'TCA records have a pid field set to a single page. This page must exist.',

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDeleted.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDeleted.php
@@ -31,6 +31,7 @@ final class TcaTablesTranslatedLanguageParentDeleted extends AbstractHealthCheck
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for not-deleted record translations with deleted parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'Record translations use the TCA ctrl field "transOrigPointerField"',

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPid.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPid.php
@@ -31,6 +31,7 @@ final class TcaTablesTranslatedLanguageParentDifferentPid extends AbstractHealth
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for record translations on wrong pid');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_UPDATE, self::TAG_SOFT_DELETE, self::TAG_REMOVE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'Record translations use the TCA ctrl field "transOrigPointerField"',

--- a/Classes/HealthCheck/TcaTablesTranslatedLanguageParentMissing.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedLanguageParentMissing.php
@@ -29,6 +29,7 @@ final class TcaTablesTranslatedLanguageParentMissing extends AbstractHealthCheck
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for record translations with missing parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'Record translations use the TCA ctrl field "transOrigPointerField"',

--- a/Classes/HealthCheck/TcaTablesTranslatedParentInvalidPointer.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedParentInvalidPointer.php
@@ -31,6 +31,7 @@ final class TcaTablesTranslatedParentInvalidPointer extends AbstractHealthCheck 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for record translations pointing to non default language parent');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_UPDATE);
         $io->text([
             'Record translations ("translate" / "connected" mode, as opposed to "free" mode) use the',

--- a/Classes/HealthCheck/WorkspacesNotLoadedRecordsDangling.php
+++ b/Classes/HealthCheck/WorkspacesNotLoadedRecordsDangling.php
@@ -32,6 +32,7 @@ final class WorkspacesNotLoadedRecordsDangling extends AbstractHealthCheck imple
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for workspace records when ext:workspaces is not loaded');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'When extension "workspaces" is not loaded, there should be no workspace overlay',

--- a/Classes/HealthCheck/WorkspacesPidNegative.php
+++ b/Classes/HealthCheck/WorkspacesPidNegative.php
@@ -31,6 +31,7 @@ final class WorkspacesPidNegative extends AbstractHealthCheck implements HealthC
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for records with negative pid');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'Records must have a pid equal or greater than zero (0).',

--- a/Classes/HealthCheck/WorkspacesRecordsOfDeletedWorkspaces.php
+++ b/Classes/HealthCheck/WorkspacesRecordsOfDeletedWorkspaces.php
@@ -35,6 +35,7 @@ final class WorkspacesRecordsOfDeletedWorkspaces extends AbstractHealthCheck imp
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for workspace records of deleted sys_workspace\'s');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([
             'When a workspace (table "sys_workspace") is deleted, all existing workspace',

--- a/Classes/HealthCheck/WorkspacesSoftDeletedRecords.php
+++ b/Classes/HealthCheck/WorkspacesSoftDeletedRecords.php
@@ -29,6 +29,7 @@ final class WorkspacesSoftDeletedRecords extends AbstractHealthCheck implements 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for soft-deleted workspaces records');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'Records in workspaces (t3ver_wsid != 0) are not soft-delete aware since TYPO3 v11:',

--- a/Classes/HealthCheck/WorkspacesT3verStateMinusOne.php
+++ b/Classes/HealthCheck/WorkspacesT3verStateMinusOne.php
@@ -29,6 +29,7 @@ final class WorkspacesT3verStateMinusOne extends AbstractHealthCheck implements 
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for records with t3ver_state=-1');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'The workspace related field state t3ver_state=-1 has been removed with TYPO3 v11.',

--- a/Classes/HealthCheck/WorkspacesT3verStateNotZeroInLive.php
+++ b/Classes/HealthCheck/WorkspacesT3verStateNotZeroInLive.php
@@ -29,9 +29,10 @@ final class WorkspacesT3verStateNotZeroInLive extends AbstractHealthCheck implem
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for records with t3ver_wsid=0 and t3ver_state!=0');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE, self::TAG_SOFT_DELETE, self::TAG_UPDATE);
         $io->text([
-            'There should be not t3ver_state non-zero (0) records in live.',
+            'There should be no t3ver_state non-zero (0) records in live.',
             'If this check finds records, ABORT NOW and run these upgrades wizards:',
             'WorkspaceVersionRecordsMigration (TYPO3 v10 & v11),',
             'WorkspaceNewPlaceholderRemovalMigration (TYPO3 11 & v12),',

--- a/Classes/HealthCheck/WorkspacesT3verStateThree.php
+++ b/Classes/HealthCheck/WorkspacesT3verStateThree.php
@@ -29,6 +29,7 @@ final class WorkspacesT3verStateThree extends AbstractHealthCheck implements Hea
     public function header(SymfonyStyle $io): void
     {
         $io->section('Scan for records with t3ver_state=3');
+        $this->outputClass($io);
         $this->outputTags($io, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'The workspace related field state t3ver_state=3 has been removed with TYPO3 v11.',


### PR DESCRIPTION
Having the class name directly in the output
makes it more easy to jump directly to the
according check class to look at details
and when issues are reported.