### PR TITLE
[TASK] First SysFileReferenceDangling more early

### DIFF
--- a/Classes/HealthCheck/SysFileReferenceLocalizedFieldSync.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedFieldSync.php
@@ -39,7 +39,7 @@ final class SysFileReferenceLocalizedFieldSync extends AbstractHealthCheck imple
             'Records violating this indicate something is wrong with this localized record.',
             'This may happen for instance, when the tt_content ctype of a default language record is changed and',
             'relations are adapted after the record has been localized. Verify findings manually!',
-            'This check sets affected localized records are set to deleted=1 in live and removes the',
+            'This check sets affected localized records to deleted=1 in live and removes them',
             'if they are workspace overlay records.',
         ]);
     }

--- a/Classes/HealthCheck/SysFileReferenceLocalizedParentExists.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedParentExists.php
@@ -24,6 +24,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Localized sys_file_reference records must point to a sys_language_uid=0 parent that exists.
+ *
+ * @todo: risky, records maybe shown in FE, but except when editing
+ *        maybe remove when soft-delete, remove if in ws, but set l10n_parent=0 if not?
  */
 final class SysFileReferenceLocalizedParentExists extends AbstractHealthCheck implements HealthCheckInterface
 {

--- a/Classes/HealthFactory/HealthFactory.php
+++ b/Classes/HealthFactory/HealthFactory.php
@@ -46,10 +46,10 @@ final class HealthFactory implements HealthFactoryInterface
         HealthCheck\TcaTablesTranslatedParentInvalidPointer::class,
         // @todo: Next one is skipped in v12 and can be dropped when v11 compat is removed from extension.
         HealthCheck\SysFileReferenceInvalidTableLocal::class,
+        HealthCheck\SysFileReferenceDangling::class,
         HealthCheck\SysFileReferenceLocalizedParentExists::class,
         HealthCheck\SysFileReferenceLocalizedParentDeleted::class,
         HealthCheck\SysFileReferenceLocalizedFieldSync::class,
-        HealthCheck\SysFileReferenceDangling::class,
         HealthCheck\SysFileReferenceInvalidPid::class,
         HealthCheck\TcaTablesPidMissing::class,
         // @todo: Disabled for now, see the class comment


### PR DESCRIPTION
The SysFileReferenceDangling check is "safe" and
should be done before the localization checks
are done to potentially reduce findings of those
already.