### PR TITLE
[TASK] Split SysFileReferenceLocalizedParentExists

### DIFF
--- a/Classes/HealthCheck/SysFileReferenceDeletedLocalizedParentExists.php
+++ b/Classes/HealthCheck/SysFileReferenceDeletedLocalizedParentExists.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolli\Dbdoctor\HealthCheck;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Lolli\Dbdoctor\Exception\NoSuchRecordException;
+use Lolli\Dbdoctor\Exception\NoSuchTableException;
+use Lolli\Dbdoctor\Helper\RecordsHelper;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Deleted localized sys_file_reference records must point to a sys_language_uid=0 parent that exists.
+ * This is the "safe" variant of SysFileReferenceLocalizedParentExists since it handles deleted=1 records only.
+ */
+final class SysFileReferenceDeletedLocalizedParentExists extends AbstractHealthCheck implements HealthCheckInterface
+{
+    public function header(SymfonyStyle $io): void
+    {
+        $io->section('Scan for localized sys_file_reference records without parent');
+        $this->outputClass($io);
+        $this->outputTags($io, self::TAG_REMOVE);
+        $io->text([
+            'Soft deleted localized records in "sys_file_reference" (sys_language_uid > 0) having',
+            'l10n_parent > 0 must point to a sys_language_uid = 0 existing language parent record.',
+            'Records violating this are removed.',
+        ]);
+    }
+
+    protected function getAffectedRecords(): array
+    {
+        /** @var RecordsHelper $recordsHelper */
+        $recordsHelper = $this->container->get(RecordsHelper::class);
+        $tableRows = [];
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_file_reference');
+        $queryBuilder->getRestrictions()->removeAll();
+        $result = $queryBuilder->select('uid', 'pid', 'sys_language_uid', 'l10n_parent')->from('sys_file_reference')
+            ->where(
+                $queryBuilder->expr()->eq('deleted', 1),
+                $queryBuilder->expr()->gt('sys_language_uid', 0),
+                $queryBuilder->expr()->gt('l10n_parent', 0)
+            )
+            ->orderBy('uid')
+            ->executeQuery();
+        while ($row = $result->fetchAssociative()) {
+            /** @var array<string, int|string> $row */
+            try {
+                $recordsHelper->getRecord('sys_file_reference', ['uid'], (int)$row['l10n_parent']);
+            } catch (NoSuchRecordException|NoSuchTableException $e) {
+                // Match if parent does not exist at all
+                $tableRows['sys_file_reference'][] = $row;
+            }
+        }
+        return $tableRows;
+    }
+
+    protected function processRecords(SymfonyStyle $io, bool $simulate, array $affectedRecords): void
+    {
+        $this->deleteTcaRecordsOfTable($io, $simulate, 'sys_file_reference', $affectedRecords['sys_file_reference'] ?? []);
+    }
+
+    protected function recordDetails(SymfonyStyle $io, array $affectedRecords): void
+    {
+        $this->outputRecordDetails($io, $affectedRecords, '', [], ['sys_language_uid', 'l10n_parent', 'deleted', 'tablenames', 'uid_foreign', 'fieldname', 'uid_local']);
+    }
+}

--- a/Classes/HealthFactory/HealthFactory.php
+++ b/Classes/HealthFactory/HealthFactory.php
@@ -47,6 +47,7 @@ final class HealthFactory implements HealthFactoryInterface
         // @todo: Next one is skipped in v12 and can be dropped when v11 compat is removed from extension.
         HealthCheck\SysFileReferenceInvalidTableLocal::class,
         HealthCheck\SysFileReferenceDangling::class,
+        HealthCheck\SysFileReferenceDeletedLocalizedParentExists::class,
         HealthCheck\SysFileReferenceLocalizedParentExists::class,
         HealthCheck\SysFileReferenceLocalizedParentDeleted::class,
         HealthCheck\SysFileReferenceLocalizedFieldSync::class,

--- a/Tests/Functional/Fixtures/SysFileReferenceDeletedLocalizedParentExistsFixed.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceDeletedLocalizedParentExistsFixed.csv
@@ -1,0 +1,8 @@
+"pages"
+,"uid","pid","title"
+,1,1,"page 1"
+"sys_file_reference"
+,"uid","pid","sys_language_uid","l10n_parent","deleted","uid_local","uid_foreign","tablenames","title"
+,1,1,0,0,0,1,1,"pages","Ok pages lang 0"
+,2,1,1,1,0,1,1,"pages","Ok pages lang 1"
+,4,1,1,3,0,1,1,"pages","OK pages lang 1 not deleted"

--- a/Tests/Functional/Fixtures/SysFileReferenceDeletedLocalizedParentExistsImport.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceDeletedLocalizedParentExistsImport.csv
@@ -1,0 +1,10 @@
+"pages"
+,"uid","pid","title"
+,1,1,"page 1"
+"sys_file_reference"
+,"uid","pid","sys_language_uid","l10n_parent","deleted","uid_local","uid_foreign","tablenames","title"
+,1,1,0,0,0,1,1,"pages","Ok pages lang 0"
+,2,1,1,1,0,1,1,"pages","Ok pages lang 1"
+,4,1,1,3,0,1,1,"pages","OK pages lang 1 not deleted"
+# Should be removed
+,6,1,1,5,1,1,1,"pages","Not Ok pages"

--- a/Tests/Functional/HealthCheck/SysFileReferenceDeletedLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceDeletedLocalizedParentExistsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolli\Dbdoctor\Tests\Functional\HealthCheck;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Lolli\Dbdoctor\HealthCheck\HealthCheckInterface;
+use Lolli\Dbdoctor\HealthCheck\SysFileReferenceDeletedLocalizedParentExists;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class SysFileReferenceDeletedLocalizedParentExistsTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/dbdoctor',
+    ];
+
+    /**
+     * @test
+     */
+    public function fixBrokenRecords(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceDeletedLocalizedParentExistsImport.csv');
+        $io = $this->getMockBuilder(SymfonyStyle::class)->disableOriginalConstructor()->getMock();
+        $io->expects(self::atLeastOnce())->method('warning');
+        /** @var SysFileReferenceDeletedLocalizedParentExists $subject */
+        $subject = $this->get(SysFileReferenceDeletedLocalizedParentExists::class);
+        $subject->handle($io, HealthCheckInterface::MODE_EXECUTE, '');
+        $this->assertCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceDeletedLocalizedParentExistsFixed.csv');
+    }
+}


### PR DESCRIPTION
Check SysFileReferenceLocalizedParentExists is a bit risky and we will work on this to communicate better with another patch.

However, sys_file_reference records that are
soft-deleted, and sys_language_uid > 0 and have an invalid l10n_parent can be removed more safely since they are deleted=1 and thus don't impact BE / FE.

We'll split those off to an own check before
SysFileReferenceLocalizedParentExists.