### PR TITLE
[TASK] SysFileReferenceLocalizedFieldSync is risky

### DIFF
--- a/Classes/HealthCheck/SysFileReferenceLocalizedFieldSync.php
+++ b/Classes/HealthCheck/SysFileReferenceLocalizedFieldSync.php
@@ -26,6 +26,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Localized sys_file_reference records must have the same data in field 'tablenames' and 'fieldname' as its language parent.
+ * Marked risky for now, but it's hard to grasp all possible scenarios. Manual interaction may be needed, at least
+ * to check affected records.
  */
 final class SysFileReferenceLocalizedFieldSync extends AbstractHealthCheck implements HealthCheckInterface
 {
@@ -33,15 +35,17 @@ final class SysFileReferenceLocalizedFieldSync extends AbstractHealthCheck imple
     {
         $io->section('Scan for localized sys_file_reference records with parent not in sync');
         $this->outputClass($io);
-        $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
+        $this->outputTags($io, self::TAG_RISKY, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
         $io->text([
             'Localized records in "sys_file_reference" (sys_language_uid > 0) must have fields "tablenames"',
             'and "fieldname" set to the same values as its language parent record.',
             'Records violating this indicate something is wrong with this localized record.',
             'This may happen for instance, when the tt_content ctype of a default language record is changed and',
-            'relations are adapted after the record has been localized. Verify findings manually!',
-            'This check sets affected localized records to deleted=1 in live and removes them',
-            'if they are workspace overlay records.',
+            'relations are adapted after the record has been localized.',
+            'This check is <error>risky</error>: It sets affected localized records to deleted=1 in live and removes',
+            'them if they are workspace overlay records. Depending on what is wrong, this may change FE output.',
+            'Look at "tablenames" and "uid_foreign" to see which inline parent record this relation is connected to,',
+            'and eventually take care of affected records yourself by creating new localizations if needed.',
         ]);
     }
 


### PR DESCRIPTION
This is about sys_file_reference "images" again.
Depending on the inline parent record, this
may potentially change FE output.