### PR TITLE
[TASK] Have basic check for tt_content on existing pid early

### DIFF
--- a/Classes/HealthCheck/TcaTablesPidMissing.php
+++ b/Classes/HealthCheck/TcaTablesPidMissing.php
@@ -43,8 +43,10 @@ final class TcaTablesPidMissing extends AbstractHealthCheck implements HealthChe
         $recordsHelper = $this->container->get(RecordsHelper::class);
 
         $affectedRows = [];
-        foreach ($this->tcaHelper->getNextTcaTable(['pages', 'sys_workspace']) as $tableName) {
-            // Iterate all TCA tables, but ignore pages table
+        foreach ($this->tcaHelper->getNextTcaTable(['pages', 'sys_workspace', 'tt_content']) as $tableName) {
+            // Iterate all TCA tables, but ignore some tables: pages of course,
+            // and tt_content has been done with TtContentPidMissing already.
+            // @todo: sys_workspace records must be pid=0 anyways - eventually have a check for this?
             $queryBuilder = $this->connectionPool->getQueryBuilderForTable($tableName);
             // Consider deleted records: If the pid does not exist, they should be deleted, too.
             $queryBuilder->getRestrictions()->removeAll();

--- a/Classes/HealthCheck/TtContentPidMissing.php
+++ b/Classes/HealthCheck/TtContentPidMissing.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolli\Dbdoctor\HealthCheck;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Lolli\Dbdoctor\Exception\NoSuchRecordException;
+use Lolli\Dbdoctor\Helper\RecordsHelper;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Records in tt_content must live on a pid that exists.
+ * This check is relatively early - tt_content is most likely a top-down page->content
+ * thing: If the page does not exist, that content will not be editable and most likely not shown.
+ * There *may* be edge cases for tt_content records that are inline children, for example with
+ * ext:news, this is ignored here.
+ *
+ * This one is an "early" version of TcaTablesPidMissing, since tt_content plays
+ * a more important role and needs earlier streamlining.
+ */
+final class TtContentPidMissing extends AbstractHealthCheck implements HealthCheckInterface
+{
+    public function header(SymfonyStyle $io): void
+    {
+        $io->section('Scan for tt_content on not existing pages');
+        $this->outputClass($io);
+        $this->outputTags($io, self::TAG_REMOVE);
+        $io->text([
+            'tt_content must have a "pid" page record that exists. Otherwise, they are most likely not editable',
+            'and can be removed. There are potential exceptions for tt_content records that are inline children',
+            'for example using "news" extension that may create such scenarios, but even then, those records',
+            'are most likely not shown in FE. You may want to look at some cases manually if this instance',
+            'has some weird scenarios where tt_content is used as inline child. Otherwise, it is usually ok',
+            'to let dbdoctor just REMOVE tt_content records that are located at a page that does not exist.',
+        ]);
+    }
+
+    protected function getAffectedRecords(): array
+    {
+        /** @var RecordsHelper $recordsHelper */
+        $recordsHelper = $this->container->get(RecordsHelper::class);
+
+        $affectedRows = [];
+        // Iterate all TCA tables, but ignore pages table
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        // Consider deleted records: If the pid does not exist, they should be deleted, too.
+        $queryBuilder->getRestrictions()->removeAll();
+        $result = $queryBuilder->select('uid', 'pid')->from('tt_content')->orderBy('uid')->executeQuery();
+        while ($row = $result->fetchAssociative()) {
+            /** @var array<string, int|string> $row */
+            if ((int)$row['pid'] === 0) {
+                // Records pointing to pid 0 are ok.
+                continue;
+            }
+            try {
+                $recordsHelper->getRecord('pages', ['uid'], (int)$row['pid']);
+            } catch (NoSuchRecordException $e) {
+                $affectedRows['tt_content'][] = $row;
+            }
+        }
+        return $affectedRows;
+    }
+
+    protected function processRecords(SymfonyStyle $io, bool $simulate, array $affectedRecords): void
+    {
+        $this->deleteTcaRecords($io, $simulate, $affectedRecords);
+    }
+}

--- a/Classes/HealthFactory/HealthFactory.php
+++ b/Classes/HealthFactory/HealthFactory.php
@@ -44,6 +44,7 @@ final class HealthFactory implements HealthFactoryInterface
         HealthCheck\PagesTranslatedLanguageParentDifferentPid::class,
         // This one is relatively early since it is rather safe and prevents loops on checks below.
         HealthCheck\TcaTablesTranslatedParentInvalidPointer::class,
+        HealthCheck\TtContentPidMissing::class,
         // @todo: Next one is skipped in v12 and can be dropped when v11 compat is removed from extension.
         HealthCheck\SysFileReferenceInvalidTableLocal::class,
         HealthCheck\SysFileReferenceDangling::class,

--- a/Tests/Functional/Fixtures/TcaTablesPidMissingImport.csv
+++ b/Tests/Functional/Fixtures/TcaTablesPidMissingImport.csv
@@ -5,8 +5,7 @@
 "be_users"
 ,"uid","pid","deleted","username"
 ,1,0,0,"Ok user on pid 0"
-"tt_content",,,,,,,,,,,,,,,,,
-,"uid","pid","deleted","t3ver_wsid","header"
-,1,0,0,0,"Ok content on pid 0"
-,2,2,0,0,"Ok content on sub page 1"
-,3,3,0,1,"Not ok content on not existing page"
+# We are misusing be_users table here since tt_content is excluded but be_users should always be on pid 0 anyways
+,2,1,0,0,"Ok user on pid 1"
+# Should be deleted
+,3,3,0,1,"Not ok user on pid 3"

--- a/Tests/Functional/Fixtures/TtContentPidMissingFixed.csv
+++ b/Tests/Functional/Fixtures/TtContentPidMissingFixed.csv
@@ -5,4 +5,7 @@
 "be_users"
 ,"uid","pid","deleted","username"
 ,1,0,0,"Ok user on pid 0"
-,2,1,0,0,"Ok user on pid 1"
+"tt_content",,,,,,,,,,,,,,,,,
+,"uid","pid","deleted","t3ver_wsid","header"
+,1,0,0,0,"Ok content on pid 0"
+,2,2,0,0,"Ok content on sub page 1"

--- a/Tests/Functional/Fixtures/TtContentPidMissingImport.csv
+++ b/Tests/Functional/Fixtures/TtContentPidMissingImport.csv
@@ -1,0 +1,12 @@
+"pages"
+,"uid","pid","deleted","t3ver_wsid","title"
+,1,0,0,0,"Ok site root"
+,2,1,0,0,"Ok sub page 1"
+"be_users"
+,"uid","pid","deleted","username"
+,1,0,0,"Ok user on pid 0"
+"tt_content",,,,,,,,,,,,,,,,,
+,"uid","pid","deleted","t3ver_wsid","header"
+,1,0,0,0,"Ok content on pid 0"
+,2,2,0,0,"Ok content on sub page 1"
+,3,3,0,1,"Not ok content on not existing page"

--- a/Tests/Functional/HealthCheck/TtContentPidMissingTest.php
+++ b/Tests/Functional/HealthCheck/TtContentPidMissingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolli\Dbdoctor\Tests\Functional\HealthCheck;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Lolli\Dbdoctor\HealthCheck\HealthCheckInterface;
+use Lolli\Dbdoctor\HealthCheck\TtContentPidMissing;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class TtContentPidMissingTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/dbdoctor',
+    ];
+
+    /**
+     * @test
+     */
+    public function fixBrokenRecords(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentPidMissingImport.csv');
+        $io = $this->getMockBuilder(SymfonyStyle::class)->disableOriginalConstructor()->getMock();
+        $io->expects(self::atLeastOnce())->method('warning');
+        /** @var TtContentPidMissing $subject */
+        $subject = $this->get(TtContentPidMissing::class);
+        $subject->handle($io, HealthCheckInterface::MODE_EXECUTE, '');
+        $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentPidMissingFixed.csv');
+    }
+}


### PR DESCRIPTION
tt_content plays an important role and we need some earlier checks to make sure things fit. The patch
extracts 'tt_content' from the later check
TcaTablesPidMissing to an earlier point.