### PR TITLE
[FEATURE] Remove deleted localized tt_content records without parent

### DIFF
--- a/Classes/HealthCheck/TtContentPidDeleted.php
+++ b/Classes/HealthCheck/TtContentPidDeleted.php
@@ -37,7 +37,7 @@ final class TtContentPidDeleted extends AbstractHealthCheck implements HealthChe
 {
     public function header(SymfonyStyle $io): void
     {
-        $io->section('Scan for tt_content on not existing pages');
+        $io->section('Scan for tt_content on soft-deleted pages');
         $this->outputClass($io);
         $this->outputTags($io, self::TAG_REMOVE);
         $io->text([

--- a/Classes/HealthFactory/HealthFactory.php
+++ b/Classes/HealthFactory/HealthFactory.php
@@ -46,6 +46,7 @@ final class HealthFactory implements HealthFactoryInterface
         HealthCheck\TcaTablesTranslatedParentInvalidPointer::class,
         HealthCheck\TtContentPidMissing::class,
         HealthCheck\TtContentPidDeleted::class,
+        HealthCheck\TtContentDeletedLocalizedParentExists::class,
         // @todo: Next one is skipped in v12 and can be dropped when v11 compat is removed from extension.
         HealthCheck\SysFileReferenceInvalidTableLocal::class,
         HealthCheck\SysFileReferenceDangling::class,

--- a/Tests/Functional/Fixtures/TtContentDeletedLocalizedParentExistsFixed.csv
+++ b/Tests/Functional/Fixtures/TtContentDeletedLocalizedParentExistsFixed.csv
@@ -1,0 +1,11 @@
+"pages"
+,"uid","pid","deleted","t3ver_wsid","title"
+,1,0,0,0,"Site root"
+,2,1,0,0,"Sub page 1"
+"tt_content",,,,,,,,,,,,,,,,,
+,"uid","pid","deleted","sys_language_uid","l18n_parent","t3ver_wsid","header"
+,1,0,0,0,0,0,"Ok content on pid 0"
+,2,2,0,0,0,0,"Ok content on sub page 1"
+,3,2,0,1,2,0,"Ok localized content on sub page 1"
+,4,2,0,1,2,1,"Ok localized content on sub page 1 ws-1"
+,5,2,1,1,2,0,"Ok localized deleted content on sub page 1"

--- a/Tests/Functional/Fixtures/TtContentDeletedLocalizedParentExistsImport.csv
+++ b/Tests/Functional/Fixtures/TtContentDeletedLocalizedParentExistsImport.csv
@@ -1,0 +1,14 @@
+"pages"
+,"uid","pid","deleted","t3ver_wsid","title"
+,1,0,0,0,"Site root"
+,2,1,0,0,"Sub page 1"
+"tt_content",,,,,,,,,,,,,,,,,
+,"uid","pid","deleted","sys_language_uid","l18n_parent","t3ver_wsid","header"
+,1,0,0,0,0,0,"Ok content on pid 0"
+,2,2,0,0,0,0,"Ok content on sub page 1"
+,3,2,0,1,2,0,"Ok localized content on sub page 1"
+,4,2,0,1,2,1,"Ok localized content on sub page 1 ws-1"
+,5,2,1,1,2,0,"Ok localized deleted content on sub page 1"
+# uid 3 missing - 7 and 8 Should be removed
+,7,3,1,1,6,0,"Not ok localized deleted content"
+,8,3,1,1,6,1,"Not ok localized deleted content ws-1"

--- a/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentExistsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolli\Dbdoctor\Tests\Functional\HealthCheck;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Lolli\Dbdoctor\HealthCheck\HealthCheckInterface;
+use Lolli\Dbdoctor\HealthCheck\TtContentDeletedLocalizedParentExists;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class TtContentDeletedLocalizedParentExistsTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/dbdoctor',
+    ];
+
+    /**
+     * @test
+     */
+    public function fixBrokenRecords(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentDeletedLocalizedParentExistsImport.csv');
+        $io = $this->getMockBuilder(SymfonyStyle::class)->disableOriginalConstructor()->getMock();
+        $io->expects(self::atLeastOnce())->method('warning');
+        /** @var TtContentDeletedLocalizedParentExists $subject */
+        $subject = $this->get(TtContentDeletedLocalizedParentExists::class);
+        $subject->handle($io, HealthCheckInterface::MODE_EXECUTE, '');
+        $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentDeletedLocalizedParentExistsFixed.csv');
+    }
+}


### PR DESCRIPTION
Similar to an existing sys_file_reference check, this one is earlier and dedicated to tt_content.