### PR TITLE
[TASK] Detect page rootline recursion loops with 'p'

### DIFF
--- a/Classes/Helper/PagesRootlineHelper.php
+++ b/Classes/Helper/PagesRootlineHelper.php
@@ -69,8 +69,16 @@ final class PagesRootlineHelper
         }
         try {
             $currentPage = $this->getPage($uid);
+            $upperPid = (int)$currentPage['pid'];
+            if (in_array($upperPid, array_column($rootline, 'pid'))) {
+                // @todo: potential health check: 'pages' should not create recursion loops.
+                throw new \RuntimeException(
+                    sprintf('Not handled pages rootline loop with uid:"%s" and pid:"%s"', $currentPage['uid'], $upperPid),
+                    1710204250
+                );
+            }
             array_unshift($rootline, $currentPage);
-            return $this->getRootline((int)$currentPage['pid'], $rootline);
+            return $this->getRootline($upperPid, $rootline);
         } catch (NoSuchPageException $e) {
             array_unshift(
                 $rootline,

--- a/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentDeletedTestFixed.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentDeletedTestFixed.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "sys_file_reference"
 ,"uid","pid","sys_language_uid","l10n_parent","deleted","t3ver_wsid","uid_local","uid_foreign","tablenames","title"
 ,1,1,0,0,0,0,1,1,"tt_content","Ok tt_content 1"

--- a/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentDeletedTestImport.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentDeletedTestImport.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "sys_file_reference"
 ,"uid","pid","sys_language_uid","l10n_parent","deleted","t3ver_wsid","uid_local","uid_foreign","tablenames","title"
 ,1,1,0,0,0,0,1,1,"tt_content","Ok tt_content 1"

--- a/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentLanguageDifferentTestFixed.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentLanguageDifferentTestFixed.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "tt_content"
 ,"uid","pid","deleted","sys_language_uid"
 ,1,1,0,0

--- a/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentLanguageDifferentTestImport.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentLanguageDifferentTestImport.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "tt_content"
 ,"uid","pid","deleted","sys_language_uid"
 ,1,1,0,0

--- a/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentMissingTestFixed.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentMissingTestFixed.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "sys_file_reference"
 ,"uid","pid","sys_language_uid","l10n_parent","deleted","uid_local","uid_foreign","tablenames","title"
 ,1,1,0,0,0,1,1,"tt_content","Ok tt_content 1"

--- a/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentMissingTestImport.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldChildrenParentMissingTestImport.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "sys_file_reference"
 ,"uid","pid","sys_language_uid","l10n_parent","deleted","uid_local","uid_foreign","tablenames","title"
 ,1,1,0,0,0,1,1,"tt_content","Ok tt_content 1"

--- a/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTestFixed.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTestFixed.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "tt_content"
 ,"uid","pid","deleted"
 ,1,1,0

--- a/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTestImport.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTestImport.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "tt_content"
 ,"uid","pid","deleted"
 ,1,1,0

--- a/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTestFixed.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTestFixed.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "tt_content"
 ,"uid","pid","deleted","sys_language_uid"
 ,1,1,0,0

--- a/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTestImport.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTestImport.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "tt_content"
 ,"uid","pid","deleted","sys_language_uid"
 ,1,1,0,0

--- a/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTestFixed.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTestFixed.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "tt_content"
 ,"uid","pid"
 ,1,1

--- a/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTestImport.csv
+++ b/Tests/Functional/Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTestImport.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "tt_content"
 ,"uid","pid"
 ,1,1

--- a/Tests/Functional/Fixtures/SysFileReferenceDeletedLocalizedParentExistsFixed.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceDeletedLocalizedParentExistsFixed.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "sys_file_reference"
 ,"uid","pid","sys_language_uid","l10n_parent","deleted","uid_local","uid_foreign","tablenames","title"
 ,1,1,0,0,0,1,1,"pages","Ok pages lang 0"

--- a/Tests/Functional/Fixtures/SysFileReferenceDeletedLocalizedParentExistsImport.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceDeletedLocalizedParentExistsImport.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 "sys_file_reference"
 ,"uid","pid","sys_language_uid","l10n_parent","deleted","uid_local","uid_foreign","tablenames","title"
 ,1,1,0,0,0,1,1,"pages","Ok pages lang 0"

--- a/Tests/Functional/Fixtures/SysFileReferenceInvalidFieldnameFixed.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceInvalidFieldnameFixed.csv
@@ -5,7 +5,7 @@
 ,4,1,0,1,2,"tt_content","does_not_exist","Not ok tt_content, but not found since tt_content has a flex field"
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 ,2,1,"page 2"
 "tt_content"
 ,"uid","pid","header"

--- a/Tests/Functional/Fixtures/SysFileReferenceInvalidFieldnameImport.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceInvalidFieldnameImport.csv
@@ -6,7 +6,7 @@
 ,4,1,0,1,2,"tt_content","does_not_exist","Not ok tt_content, but not found since tt_content has a flex field"
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 ,2,1,"page 2"
 "tt_content"
 ,"uid","pid","header"

--- a/Tests/Functional/Fixtures/SysFileReferenceInvalidPidFixed.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceInvalidPidFixed.csv
@@ -7,7 +7,7 @@
 ,5,1,0,1,2,"tt_content","Not ok tt_content"
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 ,2,1,"page 2"
 "tt_content"
 ,"uid","pid","header"

--- a/Tests/Functional/Fixtures/SysFileReferenceInvalidPidImport.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceInvalidPidImport.csv
@@ -7,7 +7,7 @@
 ,5,2,0,1,2,"tt_content","Not ok tt_content"
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"
 ,2,1,"page 2"
 "tt_content"
 ,"uid","pid","header"

--- a/Tests/Functional/Fixtures/SysFileReferenceLocalizedFieldSyncFixed.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceLocalizedFieldSyncFixed.csv
@@ -11,4 +11,4 @@
 ,9,1,5,4,1,0,1,1,"","","Not Ok pages lang 5"
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"

--- a/Tests/Functional/Fixtures/SysFileReferenceLocalizedFieldSyncImport.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceLocalizedFieldSyncImport.csv
@@ -14,4 +14,4 @@
 ,10,1,1,4,0,1,1,1,"pages","foo","Not Ok pages lang 1 ws-1"
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"

--- a/Tests/Functional/Fixtures/SysFileReferenceLocalizedParentDeletedFixed.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceLocalizedParentDeletedFixed.csv
@@ -6,4 +6,4 @@
 ,4,1,1,3,1,0,1,1,"pages","Not Ok lang 1"
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"

--- a/Tests/Functional/Fixtures/SysFileReferenceLocalizedParentDeletedImport.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceLocalizedParentDeletedImport.csv
@@ -9,4 +9,4 @@
 ,5,1,1,3,0,1,1,1,"pages","Not Ok lang 1 ws-1"
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"

--- a/Tests/Functional/Fixtures/SysFileReferenceLocalizedParentExistsFixed.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceLocalizedParentExistsFixed.csv
@@ -4,4 +4,4 @@
 ,2,1,1,1,0,1,1,"pages","Ok pages lang 1"
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"

--- a/Tests/Functional/Fixtures/SysFileReferenceLocalizedParentExistsImport.csv
+++ b/Tests/Functional/Fixtures/SysFileReferenceLocalizedParentExistsImport.csv
@@ -6,4 +6,4 @@
 ,6,1,1,5,1,1,1,"pages","Not Ok pages"
 "pages"
 ,"uid","pid","title"
-,1,1,"page 1"
+,1,0,"page 1"

--- a/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentDeletedTest.php
@@ -43,7 +43,7 @@ class InlineForeignFieldChildrenParentDeletedTest extends FunctionalTestCase
         /** @var InlineForeignFieldChildrenParentDeleted $subject */
         $subject = $this->get(InlineForeignFieldChildrenParentDeleted::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferentTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferentTest.php
@@ -38,7 +38,7 @@ class InlineForeignFieldChildrenParentLanguageDifferentTest extends FunctionalTe
         /** @var InlineForeignFieldChildrenParentLanguageDifferent $subject */
         $subject = $this->get(InlineForeignFieldChildrenParentLanguageDifferent::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentMissingTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentMissingTest.php
@@ -38,7 +38,7 @@ class InlineForeignFieldChildrenParentMissingTest extends FunctionalTestCase
         /** @var InlineForeignFieldChildrenParentMissing $subject */
         $subject = $this->get(InlineForeignFieldChildrenParentMissing::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTest.php
@@ -39,7 +39,7 @@ class InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTest extends Fun
         /** @var InlineForeignFieldNoForeignTableFieldChildrenParentDeleted $subject */
         $subject = $this->get(InlineForeignFieldNoForeignTableFieldChildrenParentDeleted::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTest.php
@@ -39,7 +39,7 @@ class InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTest e
         /** @var InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferent $subject */
         $subject = $this->get(InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferent::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTest.php
@@ -39,7 +39,7 @@ class InlineForeignFieldNoForeignTableFieldChildrenParentMissingTest extends Fun
         /** @var InlineForeignFieldNoForeignTableFieldChildrenParentMissing $subject */
         $subject = $this->get(InlineForeignFieldNoForeignTableFieldChildrenParentMissing::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/PagesBrokenTreeTest.php
+++ b/Tests/Functional/HealthCheck/PagesBrokenTreeTest.php
@@ -42,7 +42,7 @@ class PagesBrokenTreeTest extends FunctionalTestCase
         /** @var PagesBrokenTree $subject */
         $subject = $this->get(PagesBrokenTree::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDeletedTest.php
@@ -42,7 +42,7 @@ class PagesTranslatedLanguageParentDeletedTest extends FunctionalTestCase
         /** @var PagesTranslatedLanguageParentDeleted $subject */
         $subject = $this->get(PagesTranslatedLanguageParentDeleted::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDifferentPidTest.php
@@ -38,7 +38,7 @@ class PagesTranslatedLanguageParentDifferentPidTest extends FunctionalTestCase
         /** @var PagesTranslatedLanguageParentDifferentPid $subject */
         $subject = $this->get(PagesTranslatedLanguageParentDifferentPid::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentTestMissing.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentTestMissing.php
@@ -38,7 +38,7 @@ class PagesTranslatedLanguageParentTestMissing extends FunctionalTestCase
         /** @var PagesTranslatedLanguageParentMissing $subject */
         $subject = $this->get(PagesTranslatedLanguageParentMissing::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/SysFileReferenceDanglingTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceDanglingTest.php
@@ -47,7 +47,7 @@ class SysFileReferenceDanglingTest extends FunctionalTestCase
         /** @var SysFileReferenceDangling $subject */
         $subject = $this->get(SysFileReferenceDangling::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/SysFileReferenceDeletedLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceDeletedLocalizedParentExistsTest.php
@@ -38,7 +38,7 @@ class SysFileReferenceDeletedLocalizedParentExistsTest extends FunctionalTestCas
         /** @var SysFileReferenceDeletedLocalizedParentExists $subject */
         $subject = $this->get(SysFileReferenceDeletedLocalizedParentExists::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/SysFileReferenceInvalidFieldnameTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceInvalidFieldnameTest.php
@@ -38,7 +38,7 @@ class SysFileReferenceInvalidFieldnameTest extends FunctionalTestCase
         /** @var SysFileReferenceInvalidFieldname $subject */
         $subject = $this->get(SysFileReferenceInvalidFieldname::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/SysFileReferenceInvalidPidTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceInvalidPidTest.php
@@ -38,7 +38,7 @@ class SysFileReferenceInvalidPidTest extends FunctionalTestCase
         /** @var SysFileReferenceInvalidPid $subject */
         $subject = $this->get(SysFileReferenceInvalidPid::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/SysFileReferenceInvalidTableLocalTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceInvalidTableLocalTest.php
@@ -42,7 +42,7 @@ class SysFileReferenceInvalidTableLocalTest extends FunctionalTestCase
         /** @var SysFileReferenceInvalidTableLocal $subject */
         $subject = $this->get(SysFileReferenceInvalidTableLocal::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/SysFileReferenceLocalizedFieldSyncTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceLocalizedFieldSyncTest.php
@@ -42,7 +42,7 @@ class SysFileReferenceLocalizedFieldSyncTest extends FunctionalTestCase
         /** @var SysFileReferenceLocalizedFieldSync $subject */
         $subject = $this->get(SysFileReferenceLocalizedFieldSync::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentDeletedTest.php
@@ -42,7 +42,7 @@ class SysFileReferenceLocalizedParentDeletedTest extends FunctionalTestCase
         /** @var SysFileReferenceLocalizedParentDeleted $subject */
         $subject = $this->get(SysFileReferenceLocalizedParentDeleted::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentExistsTest.php
@@ -38,7 +38,7 @@ class SysFileReferenceLocalizedParentExistsTest extends FunctionalTestCase
         /** @var SysFileReferenceLocalizedParentExists $subject */
         $subject = $this->get(SysFileReferenceLocalizedParentExists::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/SysRedirectInvalidPidTest.php
+++ b/Tests/Functional/HealthCheck/SysRedirectInvalidPidTest.php
@@ -44,7 +44,7 @@ class SysRedirectInvalidPidTest extends FunctionalTestCase
         /** @var SysRedirectInvalidPid $subject */
         $subject = $this->get(SysRedirectInvalidPid::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TcaTablesDeleteFlagZeroOrOneTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesDeleteFlagZeroOrOneTest.php
@@ -42,7 +42,7 @@ class TcaTablesDeleteFlagZeroOrOneTest extends FunctionalTestCase
         /** @var TcaTablesDeleteFlagZeroOrOne $subject */
         $subject = $this->get(TcaTablesDeleteFlagZeroOrOne::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageParentTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageParentTest.php
@@ -42,7 +42,7 @@ class TcaTablesLanguageLessThanOneHasZeroLanguageParentTest extends FunctionalTe
         /** @var TcaTablesLanguageLessThanOneHasZeroLanguageParent $subject */
         $subject = $this->get(TcaTablesLanguageLessThanOneHasZeroLanguageParent::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TcaTablesPidDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesPidDeletedTest.php
@@ -42,7 +42,7 @@ class TcaTablesPidDeletedTest extends FunctionalTestCase
         /** @var TcaTablesPidDeleted $subject */
         $subject = $this->get(TcaTablesPidDeleted::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TcaTablesPidMissingTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesPidMissingTest.php
@@ -38,7 +38,7 @@ class TcaTablesPidMissingTest extends FunctionalTestCase
         /** @var TcaTablesPidMissing $subject */
         $subject = $this->get(TcaTablesPidMissing::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDeletedTest.php
@@ -42,7 +42,7 @@ class TcaTablesTranslatedLanguageParentDeletedTest extends FunctionalTestCase
         /** @var TcaTablesTranslatedLanguageParentDeleted $subject */
         $subject = $this->get(TcaTablesTranslatedLanguageParentDeleted::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPidTest.php
@@ -42,7 +42,7 @@ class TcaTablesTranslatedLanguageParentDifferentPidTest extends FunctionalTestCa
         /** @var TcaTablesTranslatedLanguageParentDifferentPid $subject */
         $subject = $this->get(TcaTablesTranslatedLanguageParentDifferentPid::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentMissingTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentMissingTest.php
@@ -38,7 +38,7 @@ class TcaTablesTranslatedLanguageParentMissingTest extends FunctionalTestCase
         /** @var TcaTablesTranslatedLanguageParentMissing $subject */
         $subject = $this->get(TcaTablesTranslatedLanguageParentMissing::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedParentInvalidPointerTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedParentInvalidPointerTest.php
@@ -38,7 +38,7 @@ class TcaTablesTranslatedParentInvalidPointerTest extends FunctionalTestCase
         /** @var TcaTablesTranslatedParentInvalidPointer $subject */
         $subject = $this->get(TcaTablesTranslatedParentInvalidPointer::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentDifferentPidTest.php
@@ -42,7 +42,7 @@ class TtContentDeletedLocalizedParentDifferentPidTest extends FunctionalTestCase
         /** @var TtContentDeletedLocalizedParentDifferentPid $subject */
         $subject = $this->get(TtContentDeletedLocalizedParentDifferentPid::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentExistsTest.php
@@ -42,7 +42,7 @@ class TtContentDeletedLocalizedParentExistsTest extends FunctionalTestCase
         /** @var TtContentDeletedLocalizedParentExists $subject */
         $subject = $this->get(TtContentDeletedLocalizedParentExists::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentLocalizationSourceExistsTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizationSourceExistsTest.php
@@ -42,7 +42,7 @@ class TtContentLocalizationSourceExistsTest extends FunctionalTestCase
         /** @var TtContentLocalizationSourceExists $subject */
         $subject = $this->get(TtContentLocalizationSourceExists::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentLocalizationSourceLogicWithParentTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizationSourceLogicWithParentTest.php
@@ -38,7 +38,7 @@ class TtContentLocalizationSourceLogicWithParentTest extends FunctionalTestCase
         /** @var TtContentLocalizationSourceLogicWithParent $subject */
         $subject = $this->get(TtContentLocalizationSourceLogicWithParent::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentLocalizationSourceSetWithParentTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizationSourceSetWithParentTest.php
@@ -42,7 +42,7 @@ class TtContentLocalizationSourceSetWithParentTest extends FunctionalTestCase
         /** @var TtContentLocalizationSourceSetWithParent $subject */
         $subject = $this->get(TtContentLocalizationSourceSetWithParent::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentLocalizedDuplicatesTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedDuplicatesTest.php
@@ -38,7 +38,7 @@ class TtContentLocalizedDuplicatesTest extends FunctionalTestCase
         /** @var TtContentLocalizedDuplicates $subject */
         $subject = $this->get(TtContentLocalizedDuplicates::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentLocalizedParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedParentDifferentPidTest.php
@@ -42,7 +42,7 @@ class TtContentLocalizedParentDifferentPidTest extends FunctionalTestCase
         /** @var TtContentLocalizedParentDifferentPid $subject */
         $subject = $this->get(TtContentLocalizedParentDifferentPid::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedParentExistsTest.php
@@ -42,7 +42,7 @@ class TtContentLocalizedParentExistsTest extends FunctionalTestCase
         /** @var TtContentLocalizedParentExists $subject */
         $subject = $this->get(TtContentLocalizedParentExists::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentLocalizedParentSoftDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedParentSoftDeletedTest.php
@@ -42,7 +42,7 @@ class TtContentLocalizedParentSoftDeletedTest extends FunctionalTestCase
         /** @var TtContentLocalizedParentSoftDeleted $subject */
         $subject = $this->get(TtContentLocalizedParentSoftDeleted::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentPidDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TtContentPidDeletedTest.php
@@ -42,7 +42,7 @@ class TtContentPidDeletedTest extends FunctionalTestCase
         /** @var TtContentPidDeleted $subject */
         $subject = $this->get(TtContentPidDeleted::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/TtContentPidMissingTest.php
+++ b/Tests/Functional/HealthCheck/TtContentPidMissingTest.php
@@ -42,7 +42,7 @@ class TtContentPidMissingTest extends FunctionalTestCase
         /** @var TtContentPidMissing $subject */
         $subject = $this->get(TtContentPidMissing::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/WorkspacesNotLoadedRecordsDanglingWorkspacesNotLoadedTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesNotLoadedRecordsDanglingWorkspacesNotLoadedTest.php
@@ -38,7 +38,7 @@ class WorkspacesNotLoadedRecordsDanglingWorkspacesNotLoadedTest extends Function
         /** @var WorkspacesNotLoadedRecordsDangling $subject */
         $subject = $this->get(WorkspacesNotLoadedRecordsDangling::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/WorkspacesRecordsOfDeletedWorkspacesTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesRecordsOfDeletedWorkspacesTest.php
@@ -42,7 +42,7 @@ class WorkspacesRecordsOfDeletedWorkspacesTest extends FunctionalTestCase
         /** @var WorkspacesRecordsOfDeletedWorkspaces $subject */
         $subject = $this->get(WorkspacesRecordsOfDeletedWorkspaces::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/WorkspacesSoftDeletedRecordsTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesSoftDeletedRecordsTest.php
@@ -42,7 +42,7 @@ class WorkspacesSoftDeletedRecordsTest extends FunctionalTestCase
         /** @var WorkspacesSoftDeletedRecords $subject */
         $subject = $this->get(WorkspacesSoftDeletedRecords::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/WorkspacesT3verStateMinusOneTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesT3verStateMinusOneTest.php
@@ -42,7 +42,7 @@ class WorkspacesT3verStateMinusOneTest extends FunctionalTestCase
         /** @var WorkspacesT3verStateMinusOne $subject */
         $subject = $this->get(WorkspacesT3verStateMinusOne::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/WorkspacesT3verStateNotZeroInLiveTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesT3verStateNotZeroInLiveTest.php
@@ -42,7 +42,7 @@ class WorkspacesT3verStateNotZeroInLiveTest extends FunctionalTestCase
         /** @var WorkspacesT3verStateNotZeroInLive $subject */
         $subject = $this->get(WorkspacesT3verStateNotZeroInLive::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 

--- a/Tests/Functional/HealthCheck/WorkspacesT3verStateThreeTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesT3verStateThreeTest.php
@@ -42,7 +42,7 @@ class WorkspacesT3verStateThreeTest extends FunctionalTestCase
         /** @var WorkspacesT3verStateThree $subject */
         $subject = $this->get(WorkspacesT3verStateThree::class);
         $io->expects(self::atLeastOnce())->method('warning');
-        $io->expects(self::atLeastOnce())->method('ask')->willReturn('d', 'a');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
         $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
     }
 


### PR DESCRIPTION
Prevent dbdoctor from crashing when there are
'pages' rootline loops.