### PR TITLE
[TASK] Ensure correct setup for cli tests

### DIFF
--- a/.github/workflows/testscorev12.yml
+++ b/.github/workflows/testscorev12.yml
@@ -52,20 +52,20 @@ jobs:
       - name: Functional Tests with sqlite
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional
 
-      #- name: Cli Tests mariadb and mysqli
-      #  run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d mariadb -i 10.5 -a mysqli
+      - name: Cli Tests mariadb and mysqli
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d mariadb -i 10.5 -a mysqli
 
-      #- name: Cli Tests mariadb and pdo_mysql
-      #  run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d mariadb -i 10.5 -a pdo_mysql
+      - name: Cli Tests mariadb and pdo_mysql
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d mariadb -i 10.5 -a pdo_mysql
 
-      #- name: Cli Tests mysql and mysqli
-      #  run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d mysql -i 8.0 -a mysqli
+      - name: Cli Tests mysql and mysqli
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d mysql -i 8.0 -a mysqli
 
-      #- name: Cli Tests mysql and pdo_mysql
-      #  run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d mysql -i 8.0 -a pdo_mysql
+      - name: Cli Tests mysql and pdo_mysql
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d mysql -i 8.0 -a pdo_mysql
 
-      #- name: Cli Tests postgres
-      #  run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d postgres -i 10
+      - name: Cli Tests postgres
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d postgres -i 10
 
-      #- name: Cli Tests sqlite
-      #  run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d sqlite
+      - name: Cli Tests sqlite
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cli -d sqlite

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -443,7 +443,7 @@ case ${TEST_SUITE} in
             mariadb)
                 ${CONTAINER_BIN} run --rm ${CI_PARAMS} --name mariadb-func-${SUFFIX} --network ${NETWORK} -d -e MYSQL_DATABASE=func -e MYSQL_ROOT_PASSWORD=funcp --tmpfs /var/lib/mysql/:rw,noexec,nosuid ${IMAGE_MARIADB} >/dev/null
                 waitFor mariadb-func-${SUFFIX} 3306
-                SETUPCOMMAND=(./.Build/bin/typo3 setup -n --force --admin-user-password=Admin123! --server-type=other --driver=mysqli --dbname=func --username=root --password=funcp --host=mariadb-func-${SUFFIX})
+                SETUPCOMMAND=(./.Build/bin/typo3 setup -n --force --admin-username=admin --admin-user-password='Admin123!' --admin-email='john.doe@example.com' --project-name='clitest' --server-type=other --driver=mysqli --dbname=func --username=root --password=funcp --host=mariadb-func-${SUFFIX})
                 ${CONTAINER_BIN} run --rm ${CONTAINER_COMMON_PARAMS} --name functional-setup-${SUFFIX} ${IMAGE_PHP} "${SETUPCOMMAND[@]}"
                 CONTAINERPARAMS="-e typo3DatabaseDriver=${DATABASE_DRIVER} -e typo3DatabaseName=func_test -e typo3DatabaseUsername=root -e typo3DatabaseHost=mariadb-func-${SUFFIX} -e typo3DatabasePassword=funcp"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
@@ -452,7 +452,7 @@ case ${TEST_SUITE} in
             mysql)
                 ${CONTAINER_BIN} run --rm ${CI_PARAMS} --name mysql-func-${SUFFIX} --network ${NETWORK} -d -e MYSQL_DATABASE=func -e MYSQL_ROOT_PASSWORD=funcp --tmpfs /var/lib/mysql/:rw,noexec,nosuid ${IMAGE_MYSQL} >/dev/null
                 waitFor mysql-func-${SUFFIX} 3306
-                SETUPCOMMAND=(./.Build/bin/typo3 setup -n --force --admin-user-password=Admin123! --server-type=other --driver=mysqli --dbname=func --username=root --password=funcp --host=mysql-func-${SUFFIX})
+                SETUPCOMMAND=(./.Build/bin/typo3 setup -n --force --admin-username=admin --admin-user-password='Admin123!' --admin-email='john.doe@example.com' --project-name='clitest' --server-type=other --driver=mysqli --dbname=func --username=root --password=funcp --host=mysql-func-${SUFFIX})
                 ${CONTAINER_BIN} run --rm ${CONTAINER_COMMON_PARAMS} --name functional-setup-${SUFFIX} ${IMAGE_PHP} "${SETUPCOMMAND[@]}"
                 CONTAINERPARAMS="-e typo3DatabaseDriver=${DATABASE_DRIVER} -e typo3DatabaseName=func_test -e typo3DatabaseUsername=root -e typo3DatabaseHost=mysql-func-${SUFFIX} -e typo3DatabasePassword=funcp"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
@@ -461,14 +461,14 @@ case ${TEST_SUITE} in
             postgres)
                 ${CONTAINER_BIN} run --rm ${CI_PARAMS} --name postgres-func-${SUFFIX} --network ${NETWORK} -d -e POSTGRES_PASSWORD=funcp -e POSTGRES_USER=funcu --tmpfs /var/lib/postgresql/data:rw,noexec,nosuid ${IMAGE_POSTGRES} >/dev/null
                 waitFor postgres-func-${SUFFIX} 5432
-                SETUPCOMMAND=(./.Build/bin/typo3 setup -n --force --admin-user-password=Admin123! --server-type=other --driver=postgres --dbname=funcu --username=funcu --password=funcp --host=postgres-func-${SUFFIX} --port=5432)
+                SETUPCOMMAND=(./.Build/bin/typo3 setup -n --force --admin-username=admin --admin-user-password='Admin123!' --admin-email='john.doe@example.com' --project-name='clitest' --server-type=other --driver=postgres --dbname=funcu --username=funcu --password=funcp --host=postgres-func-${SUFFIX} --port=5432)
                 ${CONTAINER_BIN} run --rm ${CONTAINER_COMMON_PARAMS} --name functional-setup-${SUFFIX} ${IMAGE_PHP} "${SETUPCOMMAND[@]}"
                 CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_pgsql -e typo3DatabaseName=bamboo -e typo3DatabaseUsername=funcu -e typo3DatabaseHost=postgres-func-${SUFFIX} -e typo3DatabasePassword=funcp"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;
             sqlite)
-                SETUPCOMMAND=(./.Build/bin/typo3 setup -n --force --admin-user-password=Admin123! --server-type=other --driver=sqlite)
+                SETUPCOMMAND=(./.Build/bin/typo3 setup -n --force --admin-username=admin --admin-user-password='Admin123!' --admin-email='john.doe@example.com' --project-name='clitest' --server-type=other --driver=sqlite)
                 ${CONTAINER_BIN} run --rm ${CONTAINER_COMMON_PARAMS} --name functional-setup-${SUFFIX} ${IMAGE_PHP} "${SETUPCOMMAND[@]}"
                 CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "phpstan/phpstan-phpunit": "^1.4.2",
     "phpunit/phpunit": "^10.5.45 || ^11.5.7",
     "typo3/cms-impexp": "^12.4 || ^13.4",
+    "typo3/cms-install": "^12.4 || ^13.4",
     "typo3/cms-redirects": "^12.4 || ^13.4",
     "typo3/cms-workspaces": "^12.4 || ^13.4",
     "typo3/testing-framework": "^8.2.7"


### PR DESCRIPTION
- **[TASK] Add `typo3/cms-install` as dev dependency**
  The `setup` command is part of `EXT:install` and
  required to setup instances, for example for the
  `cli` phpt based testsuite.
  
  This system extension is kind of optional and no
  longer installed by default in composer instances,
  but literally needed when the setup command should
  be used to setup instances. Add it as development
  dependency !
  
  ```shell
  composer req --dev --no-update \
    "typo3/cms-install":"^12.4 || ^13.4"
  ```
  

- **[TASK] Setup cli test instances providing all setup command arguments**
  

- **[TASK] Enable GitHub action tests for the cli testsuite**
  