### PR TITLE
[BUGFIX] Use getter instead of accessing doctrine class properties

### DIFF
--- a/Classes/DatabaseSchema/DatabaseSchemaChecker.php
+++ b/Classes/DatabaseSchema/DatabaseSchemaChecker.php
@@ -41,12 +41,12 @@ final class DatabaseSchemaChecker
             )
         );
         foreach ($databaseDifferences as $schemaDiff) {
-            if (!empty($schemaDiff->newTables)) {
+            if (!empty($schemaDiff->getCreatedTables())) {
                 // Table missing
                 return true;
             }
-            foreach ($schemaDiff->changedTables as $changedTable) {
-                if (!empty($changedTable->addedColumns)) {
+            foreach ($schemaDiff->getAlteredTables() as $changedTable) {
+                if (!empty($changedTable->getAddedColumns())) {
                     // Column missing
                     return true;
                 }
@@ -55,12 +55,13 @@ final class DatabaseSchemaChecker
                 //        This needs to be fixed in core, before the below check can
                 //        be activated as well.
                 /*
-                if (!empty($changedTable->changedColumns)) {
+                if (!empty(method_exists($changedTable, 'getChangedColumns') ? $changedTable->getChangedColumns() : $changedTable->getModifiedColumns())) {
                     // Column has to be changed
                     return true;
                 }
                 */
-                if (!empty($changedTable->addedIndexes)) {
+
+                if (!empty($changedTable->getAddedIndexes())) {
                     // Index missing
                     return true;
                 }

--- a/Tests/Functional/DatabaseSchema/DatabaseSchemaCheckerTest.php
+++ b/Tests/Functional/DatabaseSchema/DatabaseSchemaCheckerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolli\Dbdoctor\Tests\Functional\DatabaseSchema;
+
+use Lolli\Dbdoctor\DatabaseSchema\DatabaseSchemaChecker;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\DependencyInjection\Container;
+use TYPO3\CMS\Core\Database\Event\AlterTableDefinitionStatementsEvent;
+use TYPO3\CMS\Core\EventDispatcher\ListenerProvider;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+final class DatabaseSchemaCheckerTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'lolli/dbdoctor',
+    ];
+
+    private bool $addSqlDataDispatched = false;
+
+    protected function tearDown(): void
+    {
+        $this->addSqlDataDispatched = false;
+        parent::tearDown();
+    }
+
+    private function addSqlDataToSchemaMigratorListenToAlterTableDefinitionStatementsEvent(string ...$sqlStatements): void
+    {
+        $self = $this;
+        /** @var Container $container */
+        $container = $this->get('service_container');
+        $container->set(
+            'database-schema-checker-test',
+            static function (AlterTableDefinitionStatementsEvent $event) use ($sqlStatements, $self): void {
+                $self->addSqlDataDispatched = true;
+                array_map(fn(string $sql) => $event->addSqlData($sql), $sqlStatements);
+            }
+        );
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(AlterTableDefinitionStatementsEvent::class, 'database-schema-checker-test');
+    }
+
+    #[Test]
+    public function hasIncompleteTablesColumnsIndexesReturnsFalseOnCleanDatabase(): void
+    {
+        // Note that failing test may also indicate that database is not clean.
+        self::assertFalse($this->get(DatabaseSchemaChecker::class)->hasIncompleteTablesColumnsIndexes());
+    }
+
+    #[Test]
+    public function hasIncompleteTablesColumnsIndexesReturnsTrueWhenHavingTablesToCreate(): void
+    {
+        $this->addSqlDataToSchemaMigratorListenToAlterTableDefinitionStatementsEvent(
+            'CREATE TABLE a_new_table (uid INT(11) DEFAULT 0 NOT NULL);',
+        );
+        self::assertTrue($this->get(DatabaseSchemaChecker::class)->hasIncompleteTablesColumnsIndexes());
+        self::assertTrue($this->addSqlDataDispatched);
+    }
+
+    #[Test]
+    public function hasIncompleteTablesColumnsIndexesReturnsTrueWhenHavingColumnsToAdd(): void
+    {
+        $this->addSqlDataToSchemaMigratorListenToAlterTableDefinitionStatementsEvent(
+            'CREATE TABLE pages (some_field VARCHAR(10) DEFAULT \'\' NOT NULL);',
+        );
+        self::assertTrue($this->get(DatabaseSchemaChecker::class)->hasIncompleteTablesColumnsIndexes());
+        self::assertTrue($this->addSqlDataDispatched);
+    }
+
+    #[Test]
+    public function hasIncompleteTablesColumnsIndexesReturnsTrueWhenHavingIndexToAdd(): void
+    {
+        $this->addSqlDataToSchemaMigratorListenToAlterTableDefinitionStatementsEvent(
+            'CREATE TABLE pages (KEY idx_doktype (`doktype`));',
+        );
+        self::assertTrue($this->get(DatabaseSchemaChecker::class)->hasIncompleteTablesColumnsIndexes());
+        self::assertTrue($this->addSqlDataDispatched);
+    }
+}


### PR DESCRIPTION
Doctrine DBAL 4 made class properties private in most
classes, declaring them as internal api and has been
enforced with TYPO3 v13 due to the upgrade to that
version.

This change replaces property access on doctrine dbal
classes in `DatabaseSchemaChecker` with the suiting
getter method to be compatible with both TYPO3 and
Doctrine DBAL versions.

Testing `DatabaseSchemaChecker` now to cover these
API calls.
