### PR TITLE
[TASK] Use composer package name in `$testExtensionToLoad`

### DIFF
--- a/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentDeletedTest.php
@@ -30,7 +30,7 @@ class InlineForeignFieldChildrenParentDeletedTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferentTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferentTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class InlineForeignFieldChildrenParentLanguageDifferentTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentMissingTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentMissingTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class InlineForeignFieldChildrenParentMissingTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
         __DIR__ . '/../FixtureExtensions/tx_dbdoctortestsforeignfield',
     ];
 

--- a/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
         __DIR__ . '/../FixtureExtensions/tx_dbdoctortestsforeignfield',
     ];
 

--- a/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class InlineForeignFieldNoForeignTableFieldChildrenParentMissingTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
         __DIR__ . '/../FixtureExtensions/tx_dbdoctortestsforeignfield',
     ];
 

--- a/Tests/Functional/HealthCheck/PagesBrokenTreeTest.php
+++ b/Tests/Functional/HealthCheck/PagesBrokenTreeTest.php
@@ -29,7 +29,7 @@ class PagesBrokenTreeTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDeletedTest.php
@@ -29,7 +29,7 @@ class PagesTranslatedLanguageParentDeletedTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDifferentPidTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class PagesTranslatedLanguageParentDifferentPidTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentTestMissing.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentTestMissing.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class PagesTranslatedLanguageParentTestMissing extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     /**

--- a/Tests/Functional/HealthCheck/SysFileReferenceDanglingTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceDanglingTest.php
@@ -29,7 +29,7 @@ class SysFileReferenceDanglingTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/SysFileReferenceDeletedLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceDeletedLocalizedParentExistsTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class SysFileReferenceDeletedLocalizedParentExistsTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/SysFileReferenceInvalidFieldnameTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceInvalidFieldnameTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class SysFileReferenceInvalidFieldnameTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/SysFileReferenceInvalidPidTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceInvalidPidTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class SysFileReferenceInvalidPidTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/SysFileReferenceLocalizedFieldSyncTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceLocalizedFieldSyncTest.php
@@ -29,7 +29,7 @@ class SysFileReferenceLocalizedFieldSyncTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentDeletedTest.php
@@ -29,7 +29,7 @@ class SysFileReferenceLocalizedParentDeletedTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentExistsTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class SysFileReferenceLocalizedParentExistsTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/SysRedirectInvalidPidTest.php
+++ b/Tests/Functional/HealthCheck/SysRedirectInvalidPidTest.php
@@ -31,7 +31,7 @@ class SysRedirectInvalidPidTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TcaTablesDeleteFlagZeroOrOneTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesDeleteFlagZeroOrOneTest.php
@@ -29,7 +29,7 @@ class TcaTablesDeleteFlagZeroOrOneTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageParentTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageParentTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class TcaTablesLanguageLessThanOneHasZeroLanguageParentTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     protected array $coreExtensionsToLoad = [

--- a/Tests/Functional/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageSourceTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageSourceTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class TcaTablesLanguageLessThanOneHasZeroLanguageSourceTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     protected array $coreExtensionsToLoad = [

--- a/Tests/Functional/HealthCheck/TcaTablesPidDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesPidDeletedTest.php
@@ -29,7 +29,7 @@ class TcaTablesPidDeletedTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TcaTablesPidMissingTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesPidMissingTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class TcaTablesPidMissingTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDeletedTest.php
@@ -29,7 +29,7 @@ class TcaTablesTranslatedLanguageParentDeletedTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPidTest.php
@@ -29,7 +29,7 @@ class TcaTablesTranslatedLanguageParentDifferentPidTest extends FunctionalTestCa
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentMissingTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentMissingTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class TcaTablesTranslatedLanguageParentMissingTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedParentInvalidPointerTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedParentInvalidPointerTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class TcaTablesTranslatedParentInvalidPointerTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentDifferentPidTest.php
@@ -29,7 +29,7 @@ class TtContentDeletedLocalizedParentDifferentPidTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentExistsTest.php
@@ -29,7 +29,7 @@ class TtContentDeletedLocalizedParentExistsTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentLocalizationSourceExistsTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizationSourceExistsTest.php
@@ -29,7 +29,7 @@ class TtContentLocalizationSourceExistsTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentLocalizationSourceLogicWithParentTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizationSourceLogicWithParentTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class TtContentLocalizationSourceLogicWithParentTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentLocalizationSourceSetWithParentTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizationSourceSetWithParentTest.php
@@ -29,7 +29,7 @@ class TtContentLocalizationSourceSetWithParentTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentLocalizedDuplicatesTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedDuplicatesTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class TtContentLocalizedDuplicatesTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentLocalizedParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedParentDifferentPidTest.php
@@ -29,7 +29,7 @@ class TtContentLocalizedParentDifferentPidTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedParentExistsTest.php
@@ -29,7 +29,7 @@ class TtContentLocalizedParentExistsTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentLocalizedParentSoftDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedParentSoftDeletedTest.php
@@ -29,7 +29,7 @@ class TtContentLocalizedParentSoftDeletedTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentPidDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TtContentPidDeletedTest.php
@@ -29,7 +29,7 @@ class TtContentPidDeletedTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/TtContentPidMissingTest.php
+++ b/Tests/Functional/HealthCheck/TtContentPidMissingTest.php
@@ -29,7 +29,7 @@ class TtContentPidMissingTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/WorkspacesNotLoadedRecordsDanglingWorkspacesLoadedTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesNotLoadedRecordsDanglingWorkspacesLoadedTest.php
@@ -29,7 +29,7 @@ class WorkspacesNotLoadedRecordsDanglingWorkspacesLoadedTest extends FunctionalT
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/WorkspacesNotLoadedRecordsDanglingWorkspacesNotLoadedTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesNotLoadedRecordsDanglingWorkspacesNotLoadedTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class WorkspacesNotLoadedRecordsDanglingWorkspacesNotLoadedTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/WorkspacesRecordsOfDeletedWorkspacesTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesRecordsOfDeletedWorkspacesTest.php
@@ -29,7 +29,7 @@ class WorkspacesRecordsOfDeletedWorkspacesTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/WorkspacesSoftDeletedRecordsTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesSoftDeletedRecordsTest.php
@@ -29,7 +29,7 @@ class WorkspacesSoftDeletedRecordsTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/WorkspacesT3verStateMinusOneTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesT3verStateMinusOneTest.php
@@ -29,7 +29,7 @@ class WorkspacesT3verStateMinusOneTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/WorkspacesT3verStateNotZeroInLiveTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesT3verStateNotZeroInLiveTest.php
@@ -29,7 +29,7 @@ class WorkspacesT3verStateNotZeroInLiveTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/HealthCheck/WorkspacesT3verStateThreeTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesT3verStateThreeTest.php
@@ -29,7 +29,7 @@ class WorkspacesT3verStateThreeTest extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/Helper/PagesRootlineHelperTest.php
+++ b/Tests/Functional/Helper/PagesRootlineHelperTest.php
@@ -23,7 +23,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class PagesRootlineHelperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/Helper/RecordsHelperTest.php
+++ b/Tests/Functional/Helper/RecordsHelperTest.php
@@ -23,7 +23,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class RecordsHelperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]

--- a/Tests/Functional/Helper/TableHelperTest.php
+++ b/Tests/Functional/Helper/TableHelperTest.php
@@ -24,7 +24,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class TableHelperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/dbdoctor',
+        'lolli/dbdoctor',
     ];
 
     #[Test]


### PR DESCRIPTION
Since typo3/testing-framework 7.0.x it is possible to use
the composer package name to define the list of extension
to load in functional tests when they have been installed
with composer.

That includes the root packge, in this case the extension
which needs to be loaded in the tests.
