### PR TITLE
[BUGFIX] Deal with broken pages loops

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -61,9 +61,9 @@ parameters:
 			path: ../Classes/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentMissing.php
 
 		-
-			message: '#^PHPDoc tag @var with type array\<string, int\|string\> is not subtype of native type mixed\.$#'
-			identifier: varTag.nativeType
-			count: 1
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
+			count: 4
 			path: ../Classes/HealthCheck/PagesBrokenTree.php
 
 		-
@@ -299,12 +299,6 @@ parameters:
 			identifier: varTag.nativeType
 			count: 1
 			path: ../Classes/HealthCheck/WorkspacesT3verStateThree.php
-
-		-
-			message: '#^Call to function is_array\(\) with array\<string, bool\|int\|string\> will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: ../Classes/Helper/PagesRootlineHelper.php
 
 		-
 			message: '#^Cannot access offset ''SYS'' on mixed\.$#'

--- a/Classes/HealthCheck/PagesBrokenTree.php
+++ b/Classes/HealthCheck/PagesBrokenTree.php
@@ -17,7 +17,6 @@ namespace Lolli\Dbdoctor\HealthCheck;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Lolli\Dbdoctor\Helper\PagesRootlineHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -39,17 +38,44 @@ final class PagesBrokenTree extends AbstractHealthCheck implements HealthCheckIn
 
     protected function getAffectedRecords(): array
     {
-        $pagesRootlineHelper = $this->container->get(PagesRootlineHelper::class);
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
         $queryBuilder->getRestrictions()->removeAll();
         $result = $queryBuilder->select('uid', 'pid')->from('pages')->orderBy('uid')->executeQuery();
-        $danglingPages = [];
-        while ($row = $result->fetchAssociative()) {
-            /** @var array<string, int|string> $row */
-            $isInRootline = $pagesRootlineHelper->isInRootline((int)$row['uid']);
-            if (!$isInRootline) {
-                $danglingPages['pages'][] = $row;
+        $connectedPageUids = [];
+        // uid 0 is "valid"
+        $connectedPageUids[0] = true;
+        $unknownPageUidPidPairs = [];
+        while ($pageRow = $result->fetchAssociative()) {
+            if ((int)$pageRow['pid'] === 0) {
+                // Pages with pid 0 are good and sorted out already.
+                $connectedPageUids[(int)$pageRow['uid']] = true;
+            } else {
+                $unknownPageUidPidPairs[(int)$pageRow['uid']] = (int)$pageRow['pid'];
             }
+        }
+        $unknownUidPidPairsCount = count($unknownPageUidPidPairs);
+        if ($unknownUidPidPairsCount > 0) {
+            // If there are currently "unknown status" rows, have a loop that reduces the
+            // "unknown" list until it does not change anymore or is empty: Each run looks
+            // if "pid" is in "connected" list and adds itself as valid "uid" if so.
+            while (true) {
+                foreach ($unknownPageUidPidPairs as $uid => $pid) {
+                    if (array_key_exists($pid, $connectedPageUids)) {
+                        $connectedPageUids[$uid] = true;
+                        unset($unknownPageUidPidPairs[$uid]);
+                    }
+                }
+                $unknownUidPidPairsCountAfter = count($unknownPageUidPidPairs);
+                if ($unknownUidPidPairsCountAfter === 0 || $unknownUidPidPairsCountAfter === $unknownUidPidPairsCount) {
+                    break;
+                }
+                $unknownUidPidPairsCount = $unknownUidPidPairsCountAfter;
+            }
+        }
+        $danglingPages = [];
+        foreach ($unknownPageUidPidPairs as $uid => $pid) {
+            // Everything left in $unknownPageUidPidPairs is not ok.
+            $danglingPages['pages'][] = ['uid' => $uid, 'pid' => $pid];
         }
         return $danglingPages;
     }

--- a/Tests/Functional/Fixtures/PagesBrokenTreeImport.csv
+++ b/Tests/Functional/Fixtures/PagesBrokenTreeImport.csv
@@ -9,3 +9,6 @@
 # uid 7 does not exist
 ,8,7,0,0,"Lost direct parent 2"
 ,9,7,0,1,"WS page Lost direct parent"
+# two pages looping each other
+,10,11,0,0,"Not Ok loop to 11"
+,11,10,0,0,"Not Ok loop to 10"

--- a/Tests/Functional/Helper/PagesRootlineHelperTest.php
+++ b/Tests/Functional/Helper/PagesRootlineHelperTest.php
@@ -17,6 +17,7 @@ namespace Lolli\Dbdoctor\Tests\Functional\Helper;
  * The TYPO3 project - inspiring people to share!
  */
 use Lolli\Dbdoctor\Helper\PagesRootlineHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -26,215 +27,259 @@ class PagesRootlineHelperTest extends FunctionalTestCase
         'lolli/dbdoctor',
     ];
 
-    #[Test]
-    public function isInRootline(): void
+    public static function getRootlineDataProvider(): \Generator
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/PagesBrokenTreeImport.csv');
-        /** @var PagesRootlineHelper $subject */
-        $subject = $this->get(PagesRootlineHelper::class);
-        self::assertTrue($subject->isInRootline(1));
-        self::assertTrue($subject->isInRootline(2));
-        self::assertTrue($subject->isInRootline(3));
-        self::assertFalse($subject->isInRootline(4));
-        self::assertFalse($subject->isInRootline(5));
-        self::assertFalse($subject->isInRootline(6));
-        self::assertFalse($subject->isInRootline(7));
-        self::assertFalse($subject->isInRootline(8));
-        self::assertFalse($subject->isInRootline(9));
+        yield 'pid 1' => [
+            'pid' => 1,
+            'expected' => [
+                0 => [
+                    '_isMissing' => false,
+                    'uid' => 0,
+                    'pid' => 0,
+                    'deleted' => false,
+                    't3ver_wsid' => 0,
+                    'title' => 'New TYPO3 site',
+                ],
+                1 => [
+                    '_isMissing' => false,
+                    'uid' => 1,
+                    'pid' => 0,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Ok site root',
+                ],
+            ],
+        ];
+        yield 'pid 2' => [
+            'pid' => 2,
+            'expected' => [
+                0 => [
+                    '_isMissing' => false,
+                    'uid' => 0,
+                    'pid' => 0,
+                    'deleted' => false,
+                    't3ver_wsid' => 0,
+                    'title' => 'New TYPO3 site',
+                ],
+                1 => [
+                    '_isMissing' => false,
+                    'uid' => 1,
+                    'pid' => 0,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Ok site root',
+                ],
+                2 => [
+                    '_isMissing' => false,
+                    'uid' => 2,
+                    'pid' => 1,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Ok sub page 1',
+                ],
+            ],
+        ];
+        yield 'pid 3' => [
+            'pid' => 3,
+            'expected' => [
+                0 => [
+                    '_isMissing' => false,
+                    'uid' => 0,
+                    'pid' => 0,
+                    'deleted' => false,
+                    't3ver_wsid' => 0,
+                    'title' => 'New TYPO3 site',
+                ],
+                1 => [
+                    '_isMissing' => false,
+                    'uid' => 1,
+                    'pid' => 0,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Ok site root',
+                ],
+                2 => [
+                    '_isMissing' => false,
+                    'uid' => 3,
+                    'pid' => 1,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Ok sub page 2',
+                ],
+            ],
+        ];
+        yield 'pid 4' => [
+            'pid' => 4,
+            'expected' => [
+                0 => [
+                    '_isMissing' => true,
+                    'uid' => 4,
+                    'pid' => 0,
+                    'deleted' => true,
+                    't3ver_wsid' => 0,
+                    'title' => 'RECORD DOES NOT EXIST',
+                ],
+            ],
+        ];
+        yield 'pid 5' => [
+            'pid' => 5,
+            'expected' => [
+                0 => [
+                    '_isMissing' => true,
+                    'uid' => 4,
+                    'pid' => 0,
+                    'deleted' => true,
+                    't3ver_wsid' => 0,
+                    'title' => 'RECORD DOES NOT EXIST',
+                ],
+                1 => [
+                    '_isMissing' => false,
+                    'uid' => 5,
+                    'pid' => 4,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Lost direct parent 1',
+                ],
+            ],
+        ];
+        yield 'pid 6' => [
+            'pid' => 6,
+            'expected' => [
+                0 => [
+                    '_isMissing' => true,
+                    'uid' => 4,
+                    'pid' => 0,
+                    'deleted' => true,
+                    't3ver_wsid' => 0,
+                    'title' => 'RECORD DOES NOT EXIST',
+                ],
+                1 => [
+                    '_isMissing' => false,
+                    'uid' => 5,
+                    'pid' => 4,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Lost direct parent 1',
+                ],
+                2 => [
+                    '_isMissing' => false,
+                    'uid' => 6,
+                    'pid' => 5,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Sub page of not connected page',
+                ],
+            ],
+        ];
+        yield 'pid 7' => [
+            'pid' => 7,
+            'expected' => [
+                0 => [
+                    '_isMissing' => true,
+                    'uid' => 7,
+                    'pid' => 0,
+                    'deleted' => true,
+                    't3ver_wsid' => 0,
+                    'title' => 'RECORD DOES NOT EXIST',
+                ],
+            ],
+        ];
+        yield 'pid 8' => [
+            'pid' => 8,
+            'expected' => [
+                0 => [
+                    '_isMissing' => true,
+                    'uid' => 7,
+                    'pid' => 0,
+                    'deleted' => true,
+                    't3ver_wsid' => 0,
+                    'title' => 'RECORD DOES NOT EXIST',
+                ],
+                1 => [
+                    '_isMissing' => false,
+                    'uid' => 8,
+                    'pid' => 7,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Lost direct parent 2',
+                ],
+            ],
+        ];
+        yield 'pid 9' => [
+            'pid' => 9,
+            'expected' => [
+                0 => [
+                    '_isMissing' => true,
+                    'uid' => 7,
+                    'pid' => 0,
+                    'deleted' => true,
+                    't3ver_wsid' => 0,
+                    'title' => 'RECORD DOES NOT EXIST',
+                ],
+                1 => [
+                    '_isMissing' => false,
+                    'uid' => 9,
+                    'pid' => 7,
+                    'deleted' => 0,
+                    't3ver_wsid' => 1,
+                    'title' => 'WS page Lost direct parent',
+                ],
+            ],
+        ];
+        yield 'pid 10' => [
+            'pid' => 10,
+            'expected' => [
+                0 => [
+                    '_isMissing' => false,
+                    'uid' => 11,
+                    'pid' => 10,
+                    'deleted' => false,
+                    't3ver_wsid' => 0,
+                    'title' => 'Not Ok loop to 10',
+                ],
+                1 => [
+                    '_isMissing' => false,
+                    'uid' => 10,
+                    'pid' => 11,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Not Ok loop to 11',
+                ],
+            ],
+        ];
+        yield 'pid 11' => [
+            'pid' => 11,
+            'expected' => [
+                0 => [
+                    '_isMissing' => false,
+                    'uid' => 10,
+                    'pid' => 11,
+                    'deleted' => 0,
+                    't3ver_wsid' => 0,
+                    'title' => 'Not Ok loop to 11',
+                ],
+                1 => [
+                    '_isMissing' => false,
+                    'uid' => 11,
+                    'pid' => 10,
+                    'deleted' => false,
+                    't3ver_wsid' => 0,
+                    'title' => 'Not Ok loop to 10',
+                ],
+            ],
+        ];
     }
 
+    /**
+     * @param array<int, array<string, int|bool|string>> $expected
+     */
     #[Test]
-    public function getRootline(): void
+    #[DataProvider('getRootlineDataProvider')]
+    public function getRootline(int $pid, array $expected): void
     {
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/PagesBrokenTreeImport.csv');
         /** @var PagesRootlineHelper $subject */
         $subject = $this->get(PagesRootlineHelper::class);
-        $expected = [
-            0 => [
-                '_isMissing' => false,
-                'uid' => 0,
-                'pid' => 0,
-                'deleted' => false,
-                't3ver_wsid' => 0,
-                'title' => 'New TYPO3 site',
-            ],
-            1 => [
-                '_isMissing' => false,
-                'uid' => 1,
-                'pid' => 0,
-                'deleted' => 0,
-                't3ver_wsid' => 0,
-                'title' => 'Ok site root',
-            ],
-        ];
-        self::assertEquals($expected, $subject->getRootline(1));
-
-        $expected = [
-            0 => [
-                '_isMissing' => false,
-                'uid' => 0,
-                'pid' => 0,
-                'deleted' => false,
-                't3ver_wsid' => 0,
-                'title' => 'New TYPO3 site',
-            ],
-            1 => [
-                '_isMissing' => false,
-                'uid' => 1,
-                'pid' => 0,
-                'deleted' => 0,
-                't3ver_wsid' => 0,
-                'title' => 'Ok site root',
-            ],
-            2 => [
-                '_isMissing' => false,
-                'uid' => 2,
-                'pid' => 1,
-                'deleted' => 0,
-                't3ver_wsid' => 0,
-                'title' => 'Ok sub page 1',
-            ],
-        ];
-        self::assertEquals($expected, $subject->getRootline(2));
-
-        $expected = [
-            0 => [
-                '_isMissing' => false,
-                'uid' => 0,
-                'pid' => 0,
-                'deleted' => false,
-                't3ver_wsid' => 0,
-                'title' => 'New TYPO3 site',
-            ],
-            1 => [
-                '_isMissing' => false,
-                'uid' => 1,
-                'pid' => 0,
-                'deleted' => 0,
-                't3ver_wsid' => 0,
-                'title' => 'Ok site root',
-            ],
-            2 => [
-                '_isMissing' => false,
-                'uid' => 3,
-                'pid' => 1,
-                'deleted' => 0,
-                't3ver_wsid' => 0,
-                'title' => 'Ok sub page 2',
-            ],
-        ];
-        self::assertEquals($expected, $subject->getRootline(3));
-
-        $expected = [
-            0 => [
-                '_isMissing' => true,
-                'uid' => 4,
-                'pid' => 0,
-                'deleted' => true,
-                't3ver_wsid' => 0,
-                'title' => 'RECORD DOES NOT EXIST',
-            ],
-        ];
-        self::assertEquals($expected, $subject->getRootline(4));
-
-        $expected = [
-            0 => [
-                '_isMissing' => true,
-                'uid' => 4,
-                'pid' => 0,
-                'deleted' => true,
-                't3ver_wsid' => 0,
-                'title' => 'RECORD DOES NOT EXIST',
-            ],
-            1 => [
-                '_isMissing' => false,
-                'uid' => 5,
-                'pid' => 4,
-                'deleted' => 0,
-                't3ver_wsid' => 0,
-                'title' => 'Lost direct parent 1',
-            ],
-        ];
-        self::assertEquals($expected, $subject->getRootline(5));
-
-        $expected = [
-            0 => [
-                '_isMissing' => true,
-                'uid' => 4,
-                'pid' => 0,
-                'deleted' => true,
-                't3ver_wsid' => 0,
-                'title' => 'RECORD DOES NOT EXIST',
-            ],
-            1 => [
-                '_isMissing' => false,
-                'uid' => 5,
-                'pid' => 4,
-                'deleted' => 0,
-                't3ver_wsid' => 0,
-                'title' => 'Lost direct parent 1',
-            ],
-            2 => [
-                '_isMissing' => false,
-                'uid' => 6,
-                'pid' => 5,
-                'deleted' => 0,
-                't3ver_wsid' => 0,
-                'title' => 'Sub page of not connected page',
-            ],
-        ];
-        self::assertEquals($expected, $subject->getRootline(6));
-
-        $expected = [
-            0 => [
-                '_isMissing' => true,
-                'uid' => 7,
-                'pid' => 0,
-                'deleted' => true,
-                't3ver_wsid' => 0,
-                'title' => 'RECORD DOES NOT EXIST',
-            ],
-        ];
-        self::assertEquals($expected, $subject->getRootline(7));
-
-        $expected = [
-            0 => [
-                '_isMissing' => true,
-                'uid' => 7,
-                'pid' => 0,
-                'deleted' => true,
-                't3ver_wsid' => 0,
-                'title' => 'RECORD DOES NOT EXIST',
-            ],
-            1 => [
-                '_isMissing' => false,
-                'uid' => 8,
-                'pid' => 7,
-                'deleted' => 0,
-                't3ver_wsid' => 0,
-                'title' => 'Lost direct parent 2',
-            ],
-        ];
-        self::assertEquals($expected, $subject->getRootline(8));
-
-        $expected = [
-            0 => [
-                '_isMissing' => true,
-                'uid' => 7,
-                'pid' => 0,
-                'deleted' => true,
-                't3ver_wsid' => 0,
-                'title' => 'RECORD DOES NOT EXIST',
-            ],
-            1 => [
-                '_isMissing' => false,
-                'uid' => 9,
-                'pid' => 7,
-                'deleted' => 0,
-                't3ver_wsid' => 1,
-                'title' => 'WS page Lost direct parent',
-            ],
-        ];
-        self::assertEquals($expected, $subject->getRootline(9));
+        self::assertEquals($expected, $subject->getRootline($pid));
     }
 }


### PR DESCRIPTION
Implement handling for pages that pid-point to each other and thus form an invalid loop. This also speeds up "PagesBrokenTree" quite a bit since it needs no full rootline check with DB queries for each page
anymore.

Resolves: #110