### PR TITLE
[BUGFIX] Handle records having l10n_parent = uid

### DIFF
--- a/Classes/HealthCheck/PagesTranslatedLanguageParentSelf.php
+++ b/Classes/HealthCheck/PagesTranslatedLanguageParentSelf.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolli\Dbdoctor\HealthCheck;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Find localized pages that point to itself in l10n_parent.
+ */
+final class PagesTranslatedLanguageParentSelf extends AbstractHealthCheck implements HealthCheckInterface
+{
+    public function header(SymfonyStyle $io): void
+    {
+        $io->section('Check localized pages having language parent set to self');
+        $this->outputClass($io);
+        $this->outputTags($io, self::TAG_SOFT_DELETE, self::TAG_WORKSPACE_REMOVE);
+        $io->text([
+            'This health check finds not deleted but localized (sys_language_uid > 0) "pages" records',
+            'having their own uid set as their localization parent (l10n_parent = uid).',
+            'This is invalid, such page records are not listed in the BE list module and the Frontend',
+            'will most likely not render such pages.',
+            'They are soft-deleted in live and removed if they are workspace overlay records.',
+        ]);
+    }
+
+    protected function getAffectedRecords(): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+        // Do not consider page translation records that have been set to deleted already.
+        $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $result = $queryBuilder->select('uid', 'pid', 'deleted', 'sys_language_uid', 'l10n_parent', 't3ver_wsid')
+            ->from('pages')
+            ->where(
+                // sys_language_uid != 0
+                $queryBuilder->expr()->gt('sys_language_uid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                // AND uid = l10n_parent
+                $queryBuilder->expr()->eq('pages.uid', 'pages.l10n_parent')
+            )
+            ->orderBy('uid')
+            ->executeQuery();
+        $affectedRecords = [];
+        while ($row = $result->fetchAssociative()) {
+            /** @var array<string, int|string> $row */
+            $affectedRecords['pages'][] = $row;
+        }
+        return $affectedRecords;
+    }
+
+    protected function processRecords(SymfonyStyle $io, bool $simulate, array $affectedRecords): void
+    {
+        $this->softOrHardDeleteRecordsOfTable($io, $simulate, 'pages', $affectedRecords['pages'] ?? []);
+    }
+
+    protected function recordDetails(SymfonyStyle $io, array $affectedRecords): void
+    {
+        $this->outputRecordDetails($io, $affectedRecords, '', ['transOrigPointerField']);
+    }
+}

--- a/Classes/HealthCheck/TcaTablesPidDeleted.php
+++ b/Classes/HealthCheck/TcaTablesPidDeleted.php
@@ -51,7 +51,7 @@ final class TcaTablesPidDeleted extends AbstractHealthCheck implements HealthChe
             $workspaceIdField = $this->tcaHelper->getWorkspaceIdField($tableName);
             $isTableWorkspaceAware = !empty($workspaceIdField);
             $tableDeleteField = $this->tcaHelper->getDeletedField($tableName);
-            $itTableSoftDeleteAware = !empty($tableDeleteField);
+            $isTableSoftDeleteAware = !empty($tableDeleteField);
             $selectFields = ['uid', 'pid'];
             if ($isTableWorkspaceAware) {
                 $selectFields[] = $workspaceIdField;
@@ -62,7 +62,7 @@ final class TcaTablesPidDeleted extends AbstractHealthCheck implements HealthChe
             $queryBuilder->select(...$selectFields)->from($tableName)->orderBy('uid');
             $queryBuilder->where($queryBuilder->expr()->gt('pid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)));
 
-            if ($itTableSoftDeleteAware) {
+            if ($isTableSoftDeleteAware) {
                 // Do not consider deleted records: Records pointing to a not-existing page have been
                 // caught before, we want to find non-deleted records pointing to deleted pages.
                 // Still, TCA tables without soft-delete, must point to not-deleted pages.

--- a/Classes/HealthCheck/TcaTablesTranslatedParentSelf.php
+++ b/Classes/HealthCheck/TcaTablesTranslatedParentSelf.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolli\Dbdoctor\HealthCheck;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Localized records must not point to their own uid in their transOrigPointerField.
+ */
+final class TcaTablesTranslatedParentSelf extends AbstractHealthCheck implements HealthCheckInterface
+{
+    public function header(SymfonyStyle $io): void
+    {
+        $io->section('Scan for record translations pointing to self');
+        $this->outputClass($io);
+        $this->outputTags($io, self::TAG_UPDATE, self::TAG_WORKSPACE_REMOVE, self::TAG_RISKY);
+        $io->text([
+            'Record translations ("translate" / "connected" mode, as opposed to "free" mode) use the',
+            'database field "transOrigPointerField" (field name usually "l10n_parent" or "l18n_parent").',
+            'This field should point to the default language record. This health check scans for not',
+            'soft-deleted and localized records that point to their own uid in "transOrigPointerField".',
+            'They are soft-deleted in live and removed if they are workspace overlay records.',
+            'This change is considered risky since depending on configuration, such records may still be',
+            'shown in the Frontend and will disappear when deleted.',
+        ]);
+    }
+
+    protected function getAffectedRecords(): array
+    {
+        $affectedRows = [];
+        foreach ($this->tcaHelper->getNextLanguageAwareTcaTable(['pages']) as $tableName) {
+            /** @var string $languageField */
+            $languageField = $this->tcaHelper->getLanguageField($tableName);
+            /** @var string $translationParentField */
+            $translationParentField = $this->tcaHelper->getTranslationParentField($tableName);
+            $workspaceIdField = $this->tcaHelper->getWorkspaceIdField($tableName);
+            $isTableWorkspaceAware = !empty($workspaceIdField);
+            $selectFields = ['uid', 'pid', $languageField, $translationParentField];
+            if ($isTableWorkspaceAware) {
+                $selectFields[] = $workspaceIdField;
+            }
+            $queryBuilder = $this->connectionPool->getQueryBuilderForTable($tableName);
+            $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+            $result = $queryBuilder->select(...$selectFields)->from($tableName)
+                ->where(
+                    // localized records
+                    $queryBuilder->expr()->gt($languageField, $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                    // AND uid = l10n_parent
+                    $queryBuilder->expr()->eq($tableName . '.uid', $tableName . '.' . $translationParentField)
+                )
+                ->orderBy('uid')
+                ->executeQuery();
+            while ($localizedRow = $result->fetchAssociative()) {
+                /** @var array<string, int|string> $localizedRow */
+                $affectedRows[$tableName][] = $localizedRow;
+            }
+        }
+        return $affectedRows;
+    }
+
+    protected function processRecords(SymfonyStyle $io, bool $simulate, array $affectedRecords): void
+    {
+        $this->softOrHardDeleteRecords($io, $simulate, $affectedRecords);
+    }
+
+    protected function recordDetails(SymfonyStyle $io, array $affectedRecords): void
+    {
+        $this->outputRecordDetails($io, $affectedRecords, '', ['languageField', 'transOrigPointerField']);
+    }
+}

--- a/Classes/HealthFactory/HealthFactory.php
+++ b/Classes/HealthFactory/HealthFactory.php
@@ -39,9 +39,11 @@ final class HealthFactory implements HealthFactoryInterface
         HealthCheck\TcaTablesLanguageLessThanOneHasZeroLanguageParent::class,
         HealthCheck\TcaTablesLanguageLessThanOneHasZeroLanguageSource::class,
         HealthCheck\PagesBrokenTree::class,
+        HealthCheck\PagesTranslatedLanguageParentSelf::class,
         HealthCheck\PagesTranslatedLanguageParentMissing::class,
         HealthCheck\PagesTranslatedLanguageParentDeleted::class,
         HealthCheck\PagesTranslatedLanguageParentDifferentPid::class,
+        HealthCheck\TcaTablesTranslatedParentSelf::class,
         // This one is relatively early since it is rather safe and prevents loops on checks below.
         HealthCheck\TcaTablesTranslatedParentInvalidPointer::class,
         HealthCheck\TtContentPidMissing::class,

--- a/Classes/Renderer/AffectedPagesRenderer.php
+++ b/Classes/Renderer/AffectedPagesRenderer.php
@@ -21,13 +21,9 @@ use Lolli\Dbdoctor\Helper\PagesRootlineHelper;
 
 final class AffectedPagesRenderer
 {
-    private PagesRootlineHelper $pagesRootlineHelper;
-
     public function __construct(
-        PagesRootlineHelper $pagesRootlineHelper
-    ) {
-        $this->pagesRootlineHelper = $pagesRootlineHelper;
-    }
+        private readonly PagesRootlineHelper $pagesRootlineHelper,
+    ) {}
 
     /**
      * @param array<string, array<int, array<string, int|string>>> $tableRecordRows

--- a/Classes/Renderer/RecordsRenderer.php
+++ b/Classes/Renderer/RecordsRenderer.php
@@ -37,7 +37,7 @@ final class RecordsRenderer
     public function __construct(
         private readonly RecordsHelper $recordsHelper,
         private readonly TcaHelper $tcaHelper,
-        private readonly TableHelper $tableHelper
+        private readonly TableHelper $tableHelper,
     ) {}
 
     /**

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For example, when there are *two* localizations for a default language record in
 language, dbdoctor detects this as invalid and suggests to set one of them to `deleted=1`. From
 the two records, it will try to set the one deleted that is typically *not* rendered in Frontend.
 
-This general strategy isn't always as simple as with the above example, tough: Since
+This general strategy isn't always as simple as with the above example, though: Since
 the TYPO3 Frontend rendering is so flexible, the actual rendered record sometimes depends
 on specific Frontend rendering details dbdoctor can't know. In those cases, dbdoctor
 tries to guess the least amount of damage. This may not always fit real life cases.

--- a/Tests/Cli/InvalidArgumentTest.phpt
+++ b/Tests/Cli/InvalidArgumentTest.phpt
@@ -156,6 +156,19 @@ Check page tree integrity
 
  [OK] No affected records found%w
 
+Check localized pages having language parent set to self
+--------------------------------------------------------
+
+ Class: PagesTranslatedLanguageParentSelf
+ Actions: soft-delete, workspace-remove
+ This health check finds not deleted but localized (sys_language_uid > 0) "pages" records
+ having their own uid set as their localization parent (l10n_parent = uid).
+ This is invalid, such page records are not listed in the BE list module and the Frontend
+ will most likely not render such pages.
+ They are soft-deleted in live and removed if they are workspace overlay records.
+
+ [OK] No affected records found%w
+
 Check pages with missing language parent
 ----------------------------------------
 
@@ -187,6 +200,21 @@ Check pages with different pid than their language parent
  This health check finds translated "pages" records (sys_language_uid > 0) with
  their default language record (l10n_parent field) on a different pid.
  Those translated pages are shown in backend at a wrong place. They are removed.
+
+ [OK] No affected records found%w
+
+Scan for record translations pointing to self
+---------------------------------------------
+
+ Class: TcaTablesTranslatedParentSelf
+ Actions: update-fields, workspace-remove, risky
+ Record translations ("translate" / "connected" mode, as opposed to "free" mode) use the
+ database field "transOrigPointerField" (field name usually "l10n_parent" or "l18n_parent").
+ This field should point to the default language record. This health check scans for not
+ soft-deleted and localized records that point to their own uid in "transOrigPointerField".
+ They are soft-deleted in live and removed if they are workspace overlay records.
+ This change is considered risky since depending on configuration, such records may still be
+ shown in the Frontend and will disappear when deleted.
 
  [OK] No affected records found%w
 

--- a/Tests/Functional/Fixtures/PagesTranslatedLanguageParentSelfFixed.csv
+++ b/Tests/Functional/Fixtures/PagesTranslatedLanguageParentSelfFixed.csv
@@ -1,0 +1,8 @@
+"pages"
+,"uid","pid","deleted","sys_language_uid","l10n_parent","t3ver_wsid","title"
+,1,0,0,0,0,0,"Ok site root"
+,2,1,0,0,0,0,"Ok sub page 1"
+,3,1,0,1,2,0,"Ok sub page 1 translated"
+,4,1,0,0,4,0,"Ok sub page 2 default lang self parent"
+,5,1,1,1,5,0,"Ok sub page 3"
+,6,1,1,1,6,0,"Not ok sub page 4 translated self parent"

--- a/Tests/Functional/Fixtures/PagesTranslatedLanguageParentSelfImport.csv
+++ b/Tests/Functional/Fixtures/PagesTranslatedLanguageParentSelfImport.csv
@@ -1,0 +1,13 @@
+"pages"
+,"uid","pid","deleted","sys_language_uid","l10n_parent","t3ver_wsid","title"
+,1,0,0,0,0,0,"Ok site root"
+,2,1,0,0,0,0,"Ok sub page 1"
+,3,1,0,1,2,0,"Ok sub page 1 translated"
+# l10n_parent=uid with sys_language_uid=0 is fixed by TcaTablesLanguageLessThanOneHasZeroLanguageParent and should not happen here anyore
+,4,1,0,0,4,0,"Ok sub page 2 default lang self parent"
+# broken but deleted=1 already
+,5,1,1,1,5,0,"Ok sub page 3"
+# Should be set to deleted=1
+,6,1,0,1,6,0,"Not ok sub page 4 translated self parent"
+# Should be removed
+,7,1,0,1,7,1,"Not ok sub page 5 translated self parent ws-1"

--- a/Tests/Functional/Fixtures/TcaTablesTranslatedParentInvalidPointerFixed.csv
+++ b/Tests/Functional/Fixtures/TcaTablesTranslatedParentInvalidPointerFixed.csv
@@ -12,6 +12,8 @@
 ,6,2,0,2,3,0,"No ok content on sub page 1 translated"
 # ignored here l18n_parent>0 does not make sense on sys_language_uid -1 record - has own check
 ,7,2,0,-1,4,0,"Ok content on sub page 1 sys_language_uid -1"
+,8,1,0,1,8,0,"Ok lang 1 pointing to itself"
+,9,1,0,2,8,0,"Ok lang 1 pointing to broken 8"
 "sys_file_reference"
 ,"uid","pid","sys_language_uid","l10n_parent","deleted","uid_local","uid_foreign","tablenames","title"
 ,1,1,0,0,0,1,1,"pages","Ok pages lang 0"

--- a/Tests/Functional/Fixtures/TcaTablesTranslatedParentInvalidPointerImport.csv
+++ b/Tests/Functional/Fixtures/TcaTablesTranslatedParentInvalidPointerImport.csv
@@ -12,6 +12,10 @@
 ,6,2,0,2,4,0,"No ok content on sub page 1 translated"
 # ignored here l18n_parent>0 does not make sense on sys_language_uid -1 record - has own check
 ,7,2,0,-1,4,0,"Ok content on sub page 1 sys_language_uid -1"
+# skipped since it points to itself
+,8,1,0,1,8,0,"Ok lang 1 pointing to itself"
+# skipped since it points to a record that has l18n_parent=uid
+,9,1,0,2,8,0,"Ok lang 1 pointing to broken 8"
 "sys_file_reference"
 ,"uid","pid","sys_language_uid","l10n_parent","deleted","uid_local","uid_foreign","tablenames","title"
 ,1,1,0,0,0,1,1,"pages","Ok pages lang 0"

--- a/Tests/Functional/Fixtures/TcaTablesTranslatedParentSelfFixed.csv
+++ b/Tests/Functional/Fixtures/TcaTablesTranslatedParentSelfFixed.csv
@@ -1,0 +1,22 @@
+"pages"
+,"uid","pid","deleted","t3ver_wsid","title"
+,1,0,0,0,"Ok site root"
+,2,1,0,0,"Ok sub page 1"
+"tt_content"
+,"uid","pid","deleted","sys_language_uid","l18n_parent","t3ver_wsid","header"
+,1,0,0,0,0,0,"Ok content on pid 0"
+,2,0,0,1,1,0,"Ok content on pid 0 translated"
+,3,2,0,0,0,0,"Ok content 1 on sub page 1"
+,4,2,0,1,3,0,"Ok content 1 on sub page 1 translated"
+# uid=l18n_parent but sys_language_uid=0
+,5,2,0,0,5,0,"Ok content 1 on sub page 1"
+# should be set deleted=1
+,6,2,1,1,6,0,"Ok content 1 on sub page 1"
+"sys_file_reference"
+,"uid","pid","sys_language_uid","l10n_parent","deleted","uid_local","uid_foreign","tablenames","title"
+,1,1,0,0,0,1,1,"pages","Ok pages lang 0"
+,2,1,1,1,0,1,1,"pages","Ok pages lang 1"
+# uid=l10n_parent but sys_language_uid=0
+,3,1,0,3,0,1,1,"pages","Ok pages lang 1"
+# should be set deleted=1
+,4,1,1,4,1,1,1,"pages","Not ok pages lang 1"

--- a/Tests/Functional/Fixtures/TcaTablesTranslatedParentSelfImport.csv
+++ b/Tests/Functional/Fixtures/TcaTablesTranslatedParentSelfImport.csv
@@ -1,0 +1,22 @@
+"pages"
+,"uid","pid","deleted","t3ver_wsid","title"
+,1,0,0,0,"Ok site root"
+,2,1,0,0,"Ok sub page 1"
+"tt_content"
+,"uid","pid","deleted","sys_language_uid","l18n_parent","t3ver_wsid","header"
+,1,0,0,0,0,0,"Ok content on pid 0"
+,2,0,0,1,1,0,"Ok content on pid 0 translated"
+,3,2,0,0,0,0,"Ok content 1 on sub page 1"
+,4,2,0,1,3,0,"Ok content 1 on sub page 1 translated"
+# uid=l18n_parent but sys_language_uid=0
+,5,2,0,0,5,0,"Ok content 1 on sub page 1"
+# should be set deleted=1
+,6,2,0,1,6,0,"Ok content 1 on sub page 1"
+"sys_file_reference"
+,"uid","pid","sys_language_uid","l10n_parent","deleted","uid_local","uid_foreign","tablenames","title"
+,1,1,0,0,0,1,1,"pages","Ok pages lang 0"
+,2,1,1,1,0,1,1,"pages","Ok pages lang 1"
+# uid=l10n_parent but sys_language_uid=0
+,3,1,0,3,0,1,1,"pages","Ok pages lang 1"
+# should be set deleted=1
+,4,1,1,4,0,1,1,"pages","Not ok pages lang 1"

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentSelfTest.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentSelfTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolli\Dbdoctor\Tests\Functional\HealthCheck;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+use Lolli\Dbdoctor\HealthCheck\HealthCheckInterface;
+use Lolli\Dbdoctor\HealthCheck\PagesTranslatedLanguageParentSelf;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class PagesTranslatedLanguageParentSelfTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'lolli/dbdoctor',
+    ];
+
+    #[Test]
+    public function showDetails(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentSelfImport.csv');
+        $io = $this->createMock(SymfonyStyle::class);
+        /** @var PagesTranslatedLanguageParentSelf $subject */
+        $subject = $this->get(PagesTranslatedLanguageParentSelf::class);
+        $io->expects(self::atLeastOnce())->method('warning');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
+        $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
+    }
+
+    #[Test]
+    public function fixBrokenRecords(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentSelfImport.csv');
+        /** @var PagesTranslatedLanguageParentSelf $subject */
+        $subject = $this->get(PagesTranslatedLanguageParentSelf::class);
+        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $this->assertCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentSelfFixed.csv');
+    }
+}

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedParentSelfTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedParentSelfTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolli\Dbdoctor\Tests\Functional\HealthCheck;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+use Lolli\Dbdoctor\HealthCheck\HealthCheckInterface;
+use Lolli\Dbdoctor\HealthCheck\TcaTablesTranslatedParentSelf;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class TcaTablesTranslatedParentSelfTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'lolli/dbdoctor',
+    ];
+
+    #[Test]
+    public function showDetails(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedParentSelfImport.csv');
+        $io = $this->createMock(SymfonyStyle::class);
+        /** @var TcaTablesTranslatedParentSelf $subject */
+        $subject = $this->get(TcaTablesTranslatedParentSelf::class);
+        $io->expects(self::atLeastOnce())->method('warning');
+        $io->expects(self::atLeastOnce())->method('ask')->willReturn('p', 'd', 'a');
+        $subject->handle($io, HealthCheckInterface::MODE_INTERACTIVE, '');
+    }
+
+    #[Test]
+    public function fixBrokenRecords(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedParentSelfImport.csv');
+        /** @var TcaTablesTranslatedParentSelf $subject */
+        $subject = $this->get(TcaTablesTranslatedParentSelf::class);
+        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedParentSelfFixed.csv');
+    }
+}


### PR DESCRIPTION
TcaTablesTranslatedParentInvalidPointer stumbles when it encounters a records having "transOrigPointerField" (l10n_parent) set to its own uid. It also stumbles when an l10n_parent of a different row points to such a record.

To fix this, two new checks are added: Scan for such records in pages and set them deleted, then scan for such records in all other tables and set them deleted.

Additionally, sanitize TcaTablesTranslatedParentInvalidPointer to skip such records which may happen if the check has to run multiple times in one run because it follows a chain.