### PR TITLE
[BUGFIX] Avoid null as array offset

### DIFF
--- a/Classes/HealthCheck/TcaTablesDeleteFlagZeroOrOne.php
+++ b/Classes/HealthCheck/TcaTablesDeleteFlagZeroOrOne.php
@@ -69,6 +69,12 @@ final class TcaTablesDeleteFlagZeroOrOne extends AbstractHealthCheck implements 
         foreach ($affectedRecords as $tableName => $tableRows) {
             // Force "deleted=1" for affected rows.
             $deletedField = $this->tcaHelper->getDeletedField($tableName);
+            if ($deletedField === null) {
+                throw new \RuntimeException(
+                    'The delete field must not be empty. This exception indicates a bug in getNextSoftDeleteAwareTable()',
+                    1761914758
+                );
+            }
             $updateFields = [
                 $deletedField => [
                     'value' => 1,

--- a/Classes/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageParent.php
+++ b/Classes/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageParent.php
@@ -71,6 +71,12 @@ final class TcaTablesLanguageLessThanOneHasZeroLanguageParent extends AbstractHe
     {
         foreach ($affectedRecords as $tableName => $tableRows) {
             $translationParentField = $this->tcaHelper->getTranslationParentField($tableName);
+            if ($translationParentField === null) {
+                throw new \RuntimeException(
+                    'TCA ctrl transOrigPointerField null, indicates bug in getNextLanguageAwareTcaTable()',
+                    1761914821
+                );
+            }
             $updateFields = [
                 $translationParentField => [
                     'value' => 0,

--- a/Classes/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageSource.php
+++ b/Classes/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageSource.php
@@ -72,6 +72,12 @@ final class TcaTablesLanguageLessThanOneHasZeroLanguageSource extends AbstractHe
     {
         foreach ($affectedRecords as $tableName => $tableRows) {
             $translationSourceField = $this->tcaHelper->getTranslationSourceField($tableName);
+            if ($translationSourceField === null) {
+                throw new \RuntimeException(
+                    'TCA ctrl translationSource null, indicates bug in getNextLanguageSourceAwareTcaTable()',
+                    1761914882
+                );
+            }
             $updateFields = [
                 $translationSourceField => [
                     'value' => 0,


### PR DESCRIPTION
PHP 8.5 raises deprecation level errors when using null values as array offset. Sanitize according
phpstan findings.