### PR TITLE
[TASK] Add v14 compat, remove v12

### DIFF
--- a/.github/workflows/testscorev14.yml
+++ b/.github/workflows/testscorev14.yml
@@ -1,4 +1,4 @@
-name: tests core v12
+name: tests core v14
 
 on:
   push:
@@ -8,18 +8,18 @@ on:
 
 jobs:
   testsuite:
-    name: all tests with core v12
+    name: all tests with core v14
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php: [ '8.2', '8.3', '8.4', '8.5' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
       - name: Install testing system
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t 12 -s composerUpdate
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t 14 -s composerUpdate
 
       - name: Lint PHP
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
@@ -27,9 +27,6 @@ jobs:
       - name: CGL
         if: ${{ matrix.php <= '8.3' }}
         run: Build/Scripts/runTests.sh -n -p ${{ matrix.php }} -s cgl
-
-      - name: phpstan
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
 
       - name: Unit Tests
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -124,9 +124,6 @@ handleDbmsOptions() {
 
 getPhpImageVersion() {
     case ${1} in
-        8.1)
-            echo -n "2.13"
-            ;;
         8.2)
             echo -n "1.13"
             ;;
@@ -152,7 +149,7 @@ Recommended docker version is >=20.10 for xdebug break pointing to work reliably
 
 Usage: $0 [options] [file]
 
-No arguments: Run all unit tests with PHP 8.1
+No arguments: Run all unit tests with PHP 8.2
 
 Options:
     -s <...>
@@ -228,19 +225,18 @@ Options:
             - 15    maintained until 2027-11-11
             - 16    maintained until 2028-11-09
 
-    -p <8.1|8.2|8.3|8.4>
+    -p <8.2|8.3|8.4|8.5>
         Specifies the PHP minor version to be used
-            - 8.1: use PHP 8.1
             - 8.2: (default) use PHP 8.2
             - 8.3: use PHP 8.3
             - 8.4: use PHP 8.4
             - 8.5: use PHP 8.5
 
-    -t <12|13>
+    -t <13|14>
         Only with -s composerUpdate
         Specifies the TYPO3 core major version to be used
-            - 12 (default): use TYPO3 core v12
-            - 13: Use TYPO3 core v13
+            - 13 (default): use TYPO3 core v13
+            - 14: Use TYPO3 core v14
 
     -x
         Only with -s functional|unit|cli
@@ -260,7 +256,7 @@ Options:
         Show this help.
 
 Examples:
-    # Run unit tests using PHP 8.1
+    # Run unit tests using PHP 8.2
     ./Build/Scripts/runTests.sh
 EOF
 }
@@ -296,7 +292,7 @@ CI_JOB_ID=${CI_JOB_ID:-}
 SUFFIX=$(echo $RANDOM)
 NETWORK="typo3-core-${SUFFIX}"
 CONTAINER_HOST="host.docker.internal"
-TYPO3_VERSION="12"
+TYPO3_VERSION="13"
 
 # Option parsing updates above default vars
 # Reset in case getopts has been used previously in the shell
@@ -326,17 +322,14 @@ while getopts ":s:a:b:d:i:p:t:e:xnhuv" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(8.1|8.2|8.3|8.4|8.5)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(8.2|8.3|8.4|8.5)$ ]]; then
                 INVALID_OPTIONS+=("p ${OPTARG}")
             fi
             ;;
         t)
             TYPO3_VERSION=${OPTARG}
-            if ! [[ ${TYPO3_VERSION} =~ ^(12|13)$ ]]; then
+            if ! [[ ${TYPO3_VERSION} =~ ^(13|14)$ ]]; then
                 INVALID_OPTIONS+=("t ${OPTARG}")
-            fi
-            if [[ (${TYPO3_VERSION} == "13" && ${PHP_VERSION} == "8.1") ]]; then
-                INVALID_OPTIONS+=("t ${OPTARG} with -p 8.1")
             fi
             ;;
         x)
@@ -485,18 +478,20 @@ case ${TEST_SUITE} in
         ;;
     composerUpdate)
         cp composer.json composer.json.orig
-        if [ ${TYPO3_VERSION} -eq 12 ]; then
-            COMMAND=(composer req --dev --no-update --no-interaction typo3/cms-composer-installers:^5.0 typo3/cms-workspaces:^12.4 typo3/cms-impexp:^12.4 typo3/cms-redirects:^12.4 "$@")
-            ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-update-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
-            COMMAND=(composer req --no-update --no-interaction typo3/cms-core:^12.4 "$@")
-            ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-update-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
-        fi
         if [ ${TYPO3_VERSION} -eq 13 ]; then
             COMMAND=(composer req --dev --no-update --no-interaction typo3/cms-composer-installers:^5.0 typo3/cms-workspaces:^13.4 typo3/cms-impexp:^13.4 typo3/cms-redirects:^13.4 "$@")
             ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-update-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
             COMMAND=(composer rm --no-update --no-interaction --dev typo3/cms-install "$@")
             ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-update-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
             COMMAND=(composer req --no-update --no-interaction typo3/cms-core:^13.4 typo3/cms-install:^13.4 "$@")
+            ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-update-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        fi
+        if [ ${TYPO3_VERSION} -eq 14 ]; then
+            COMMAND=(composer req --dev --no-update --no-interaction typo3/cms-composer-installers:^5.0 typo3/cms-workspaces:^14.3 typo3/cms-impexp:^14.3 typo3/cms-redirects:^14.3 "$@")
+            ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-update-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+            COMMAND=(composer rm --no-update --no-interaction --dev typo3/cms-install "$@")
+            ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-update-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+            COMMAND=(composer req --no-update --no-interaction typo3/cms-core:^14.3 typo3/cms-install:^14.3 "$@")
             ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-update-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
         fi
         COMMAND=(composer update --no-progress --no-interaction "$@")

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![tests core v12](https://github.com/lolli42/dbdoctor/actions/workflows/testscorev12.yml/badge.svg)
 ![tests core v13](https://github.com/lolli42/dbdoctor/actions/workflows/testscorev13.yml/badge.svg)
+![tests core v14](https://github.com/lolli42/dbdoctor/actions/workflows/testscorev14.yml/badge.svg)
 
 TYPO3 DB doctor
 ===============
@@ -151,7 +151,7 @@ blindly!
 
 ## Composer
 
-The extension currently supports TYPO3 v12 and TYPO3 v13. The extension can be installed
+The extension currently supports TYPO3 v13 and TYPO3 v14. The extension can be installed
 as non-dev dependency (not adding `--dev` to `composer require`): It has no impact on a
 live instance (except dependency injection definitions) as long as it is not actively
 executed via CLI.
@@ -374,6 +374,7 @@ Build/Scripts/runTests.sh -s clean
 Build/Scripts/runTests.sh -s composerUpdate
 composer req --dev typo3/tailor
 .Build/bin/tailor set-version 0.3.2
+composer config extra.typo3/cms.version 0.3.2
 composer rem --dev typo3/tailor
 git commit -am "[RELEASE] 0.3.2 Added some basic inline foreign field related checks"
 git tag 0.3.2

--- a/Tests/Functional/FixtureExtensions/tx_dbdoctortestsforeignfield/composer.json
+++ b/Tests/Functional/FixtureExtensions/tx_dbdoctortestsforeignfield/composer.json
@@ -4,11 +4,15 @@
 	"description": "A test extension for dbdoctor",
 	"license": "GPL-2.0-or-later",
 	"require": {
-    "typo3/cms-core": "^11.5 || ^12.4"
+		"typo3/cms-core": "^13.4 || ^14.3"
 	},
 	"extra": {
 		"typo3/cms": {
-			"extension-key": "tx_dbdoctortestsforeignfield"
+			"extension-key": "tx_dbdoctortestsforeignfield",
+			"version": "1.0.0",
+			"Package": {
+				"providesPackages": {}
+			}
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "GPL-2.0-or-later"
   ],
   "require": {
-    "php": "^8.1",
-    "typo3/cms-core": "^12.4 || ^13.4"
+    "php": "^8.2",
+    "typo3/cms-core": "^13.4 || ^14.3"
   },
   "config": {
     "sort-packages": true,
@@ -31,11 +31,11 @@
     "phpstan/phpstan": "^2.1.17",
     "phpstan/phpstan-phpunit": "^2.0.6",
     "phpunit/phpunit": "^10.5.47 || ^11.5.26 || ^12.2.6",
-    "typo3/cms-impexp": "^12.4 || ^13.4",
-    "typo3/cms-install": "^12.4 || ^13.4",
-    "typo3/cms-redirects": "^12.4 || ^13.4",
-    "typo3/cms-workspaces": "^12.4 || ^13.4",
-    "typo3/testing-framework": "^8.2.7 || ^9.2.0"
+    "typo3/cms-impexp": "^13.4 || ^14.3",
+    "typo3/cms-install": "^13.4 || ^14.3",
+    "typo3/cms-redirects": "^13.4 || ^14.3",
+    "typo3/cms-workspaces": "^13.4 || ^14.3",
+    "typo3/testing-framework": "^9.5.0"
   },
   "autoload": {
     "psr-4": {
@@ -49,12 +49,16 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-main": "1.x-dev"
+      "dev-main": "2.x-dev"
     },
     "typo3/cms": {
       "app-dir": ".Build",
       "web-dir": ".Build/Web",
-      "extension-key": "dbdoctor"
+      "extension-key": "dbdoctor",
+      "version": "2.0.0",
+      "Package": {
+        "providesPackages": []
+      }
     }
   }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF['dbdoctor'] = [
     'author_email' => 'lolli@schwarzbu.ch',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.99.99',
+            'typo3' => '13.4.0-14.99.99',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
Main composer commands, GH workflows, README.md,
runTests.sh, ext_emconf.php, test fixture adaptions.

> composer require --no-update \
    'php:^8.2' \
    'typo3/cms-core:^13.4 || ^14.3'
> composer require --dev --no-update \
    'typo3/cms-impexp:^13.4 || ^14.3' \
    'typo3/cms-install:^13.4 || ^14.3' \
    'typo3/cms-redirects:^13.4 || ^14.3' \
    'typo3/cms-workspaces:^13.4 || ^14.3' \
    'typo3/testing-framework:^9.5.0'