### PR TITLE
[TASK] Use createStub() for parameter-only SymfonyStyle test doubles

### DIFF
--- a/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentDeletedTest.php
@@ -51,7 +51,7 @@ class InlineForeignFieldChildrenParentDeletedTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldChildrenParentDeletedTestImport.csv');
         /** @var InlineForeignFieldChildrenParentDeleted $subject */
         $subject = $this->get(InlineForeignFieldChildrenParentDeleted::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldChildrenParentDeletedTestFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferentTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentLanguageDifferentTest.php
@@ -46,7 +46,7 @@ class InlineForeignFieldChildrenParentLanguageDifferentTest extends FunctionalTe
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldChildrenParentLanguageDifferentTestImport.csv');
         /** @var InlineForeignFieldChildrenParentLanguageDifferent $subject */
         $subject = $this->get(InlineForeignFieldChildrenParentLanguageDifferent::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldChildrenParentLanguageDifferentTestFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentMissingTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldChildrenParentMissingTest.php
@@ -46,7 +46,7 @@ class InlineForeignFieldChildrenParentMissingTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldChildrenParentMissingTestImport.csv');
         /** @var InlineForeignFieldChildrenParentMissing $subject */
         $subject = $this->get(InlineForeignFieldChildrenParentMissing::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldChildrenParentMissingTestFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTest.php
@@ -47,7 +47,7 @@ class InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTest extends Fun
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTestImport.csv');
         /** @var InlineForeignFieldNoForeignTableFieldChildrenParentDeleted $subject */
         $subject = $this->get(InlineForeignFieldNoForeignTableFieldChildrenParentDeleted::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentDeletedTestFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTest.php
@@ -47,7 +47,7 @@ class InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTest e
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTestImport.csv');
         /** @var InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferent $subject */
         $subject = $this->get(InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferent::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentLanguageDifferentTestFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTest.php
+++ b/Tests/Functional/HealthCheck/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTest.php
@@ -47,7 +47,7 @@ class InlineForeignFieldNoForeignTableFieldChildrenParentMissingTest extends Fun
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTestImport.csv');
         /** @var InlineForeignFieldNoForeignTableFieldChildrenParentMissing $subject */
         $subject = $this->get(InlineForeignFieldNoForeignTableFieldChildrenParentMissing::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/InlineForeignFieldNoForeignTableFieldChildrenParentMissingTestFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/PagesBrokenTreeTest.php
+++ b/Tests/Functional/HealthCheck/PagesBrokenTreeTest.php
@@ -50,7 +50,7 @@ class PagesBrokenTreeTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/PagesBrokenTreeImport.csv');
         /** @var PagesBrokenTree $subject */
         $subject = $this->get(PagesBrokenTree::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/PagesBrokenTreeFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDeletedTest.php
@@ -50,7 +50,7 @@ class PagesTranslatedLanguageParentDeletedTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentDeletedImport.csv');
         /** @var PagesTranslatedLanguageParentDeleted $subject */
         $subject = $this->get(PagesTranslatedLanguageParentDeleted::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentDeletedFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentDifferentPidTest.php
@@ -50,7 +50,7 @@ class PagesTranslatedLanguageParentDifferentPidTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentDifferentPidImport.csv');
         /** @var PagesTranslatedLanguageParentDifferentPid $subject */
         $subject = $this->get(PagesTranslatedLanguageParentDifferentPid::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentDifferentPidFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentMissingTest.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentMissingTest.php
@@ -47,7 +47,7 @@ class PagesTranslatedLanguageParentMissingTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentMissingImport.csv');
         /** @var PagesTranslatedLanguageParentMissing $subject */
         $subject = $this->get(PagesTranslatedLanguageParentMissing::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentMissingFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentSelfTest.php
+++ b/Tests/Functional/HealthCheck/PagesTranslatedLanguageParentSelfTest.php
@@ -50,7 +50,7 @@ class PagesTranslatedLanguageParentSelfTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentSelfImport.csv');
         /** @var PagesTranslatedLanguageParentSelf $subject */
         $subject = $this->get(PagesTranslatedLanguageParentSelf::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/PagesTranslatedLanguageParentSelfFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/SysFileReferenceDanglingTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceDanglingTest.php
@@ -50,7 +50,7 @@ class SysFileReferenceDanglingTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceDanglingImport.csv');
         /** @var SysFileReferenceDangling $subject */
         $subject = $this->get(SysFileReferenceDangling::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceDanglingFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/SysFileReferenceDeletedLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceDeletedLocalizedParentExistsTest.php
@@ -46,7 +46,7 @@ class SysFileReferenceDeletedLocalizedParentExistsTest extends FunctionalTestCas
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceDeletedLocalizedParentExistsImport.csv');
         /** @var SysFileReferenceDeletedLocalizedParentExists $subject */
         $subject = $this->get(SysFileReferenceDeletedLocalizedParentExists::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceDeletedLocalizedParentExistsFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/SysFileReferenceInvalidFieldnameTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceInvalidFieldnameTest.php
@@ -46,7 +46,7 @@ class SysFileReferenceInvalidFieldnameTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceInvalidFieldnameImport.csv');
         /** @var SysFileReferenceInvalidFieldname $subject */
         $subject = $this->get(SysFileReferenceInvalidFieldname::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceInvalidFieldnameFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/SysFileReferenceInvalidPidTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceInvalidPidTest.php
@@ -46,7 +46,7 @@ class SysFileReferenceInvalidPidTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceInvalidPidImport.csv');
         /** @var SysFileReferenceInvalidPid $subject */
         $subject = $this->get(SysFileReferenceInvalidPid::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceInvalidPidFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/SysFileReferenceLocalizedFieldSyncTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceLocalizedFieldSyncTest.php
@@ -50,7 +50,7 @@ class SysFileReferenceLocalizedFieldSyncTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceLocalizedFieldSyncImport.csv');
         /** @var SysFileReferenceLocalizedFieldSync $subject */
         $subject = $this->get(SysFileReferenceLocalizedFieldSync::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceLocalizedFieldSyncFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentDeletedTest.php
@@ -50,7 +50,7 @@ class SysFileReferenceLocalizedParentDeletedTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceLocalizedParentDeletedImport.csv');
         /** @var SysFileReferenceLocalizedParentDeleted $subject */
         $subject = $this->get(SysFileReferenceLocalizedParentDeleted::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceLocalizedParentDeletedFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/SysFileReferenceLocalizedParentExistsTest.php
@@ -46,7 +46,7 @@ class SysFileReferenceLocalizedParentExistsTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceLocalizedParentExistsImport.csv');
         /** @var SysFileReferenceLocalizedParentExists $subject */
         $subject = $this->get(SysFileReferenceLocalizedParentExists::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/SysFileReferenceLocalizedParentExistsFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/SysRedirectInvalidPidTest.php
+++ b/Tests/Functional/HealthCheck/SysRedirectInvalidPidTest.php
@@ -54,7 +54,7 @@ class SysRedirectInvalidPidTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/SysRedirectInvalidPidImport.csv');
         /** @var SysRedirectInvalidPid $subject */
         $subject = $this->get(SysRedirectInvalidPid::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/SysRedirectInvalidPidFixed.csv');
     }
 

--- a/Tests/Functional/HealthCheck/TcaTablesDeleteFlagZeroOrOneTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesDeleteFlagZeroOrOneTest.php
@@ -50,7 +50,7 @@ class TcaTablesDeleteFlagZeroOrOneTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesDeleteFlagZeroOrOneImport.csv');
         /** @var TcaTablesDeleteFlagZeroOrOne $subject */
         $subject = $this->get(TcaTablesDeleteFlagZeroOrOne::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesDeleteFlagZeroOrOneFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageParentTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageParentTest.php
@@ -50,7 +50,7 @@ class TcaTablesLanguageLessThanOneHasZeroLanguageParentTest extends FunctionalTe
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesLanguageLessThanOneHasZeroLanguageParentImport.csv');
         /** @var TcaTablesLanguageLessThanOneHasZeroLanguageParent $subject */
         $subject = $this->get(TcaTablesLanguageLessThanOneHasZeroLanguageParent::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesLanguageLessThanOneHasZeroLanguageParentFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageSourceTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesLanguageLessThanOneHasZeroLanguageSourceTest.php
@@ -50,7 +50,7 @@ class TcaTablesLanguageLessThanOneHasZeroLanguageSourceTest extends FunctionalTe
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesLanguageLessThanOneHasZeroLanguageSourceImport.csv');
         /** @var TcaTablesLanguageLessThanOneHasZeroLanguageSource $subject */
         $subject = $this->get(TcaTablesLanguageLessThanOneHasZeroLanguageSource::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesLanguageLessThanOneHasZeroLanguageSourceFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TcaTablesPidDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesPidDeletedTest.php
@@ -50,7 +50,7 @@ class TcaTablesPidDeletedTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesPidDeletedImport.csv');
         /** @var TcaTablesPidDeleted $subject */
         $subject = $this->get(TcaTablesPidDeleted::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesPidDeletedFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TcaTablesPidMissingTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesPidMissingTest.php
@@ -46,7 +46,7 @@ class TcaTablesPidMissingTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesPidMissingImport.csv');
         /** @var TcaTablesPidMissing $subject */
         $subject = $this->get(TcaTablesPidMissing::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesPidMissingFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDeletedTest.php
@@ -50,7 +50,7 @@ class TcaTablesTranslatedLanguageParentDeletedTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedLanguageParentDeletedImport.csv');
         /** @var TcaTablesTranslatedLanguageParentDeleted $subject */
         $subject = $this->get(TcaTablesTranslatedLanguageParentDeleted::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedLanguageParentDeletedFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentDifferentPidTest.php
@@ -50,7 +50,7 @@ class TcaTablesTranslatedLanguageParentDifferentPidTest extends FunctionalTestCa
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedLanguageParentDifferentPidImport.csv');
         /** @var TcaTablesTranslatedLanguageParentDifferentPid $subject */
         $subject = $this->get(TcaTablesTranslatedLanguageParentDifferentPid::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedLanguageParentDifferentPidFixed.csv');
     }
 
@@ -61,7 +61,7 @@ class TcaTablesTranslatedLanguageParentDifferentPidTest extends FunctionalTestCa
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedLanguageParentDifferentPidTtContentNotHiddenAwareImport.csv');
         /** @var TcaTablesTranslatedLanguageParentDifferentPid $subject */
         $subject = $this->get(TcaTablesTranslatedLanguageParentDifferentPid::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedLanguageParentDifferentPidTtContentNotHiddenAwareFixed.csv');
     }
 
@@ -73,7 +73,7 @@ class TcaTablesTranslatedLanguageParentDifferentPidTest extends FunctionalTestCa
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedLanguageParentDifferentPidTtContentNotHiddenNotDeleteAwareImport.csv');
         /** @var TcaTablesTranslatedLanguageParentDifferentPid $subject */
         $subject = $this->get(TcaTablesTranslatedLanguageParentDifferentPid::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedLanguageParentDifferentPidTtContentNotHiddenNotDeleteAwareFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentMissingTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedLanguageParentMissingTest.php
@@ -46,7 +46,7 @@ class TcaTablesTranslatedLanguageParentMissingTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedLanguageParentMissingImport.csv');
         /** @var TcaTablesTranslatedLanguageParentMissing $subject */
         $subject = $this->get(TcaTablesTranslatedLanguageParentMissing::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedLanguageParentMissingFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedParentInvalidPointerTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedParentInvalidPointerTest.php
@@ -46,7 +46,7 @@ class TcaTablesTranslatedParentInvalidPointerTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedParentInvalidPointerImport.csv');
         /** @var TcaTablesTranslatedParentInvalidPointer $subject */
         $subject = $this->get(TcaTablesTranslatedParentInvalidPointer::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedParentInvalidPointerFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TcaTablesTranslatedParentSelfTest.php
+++ b/Tests/Functional/HealthCheck/TcaTablesTranslatedParentSelfTest.php
@@ -46,7 +46,7 @@ class TcaTablesTranslatedParentSelfTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedParentSelfImport.csv');
         /** @var TcaTablesTranslatedParentSelf $subject */
         $subject = $this->get(TcaTablesTranslatedParentSelf::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TcaTablesTranslatedParentSelfFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentDifferentPidTest.php
@@ -50,7 +50,7 @@ class TtContentDeletedLocalizedParentDifferentPidTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentDeletedLocalizedParentDifferentPidImport.csv');
         /** @var TtContentDeletedLocalizedParentDifferentPid $subject */
         $subject = $this->get(TtContentDeletedLocalizedParentDifferentPid::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentDeletedLocalizedParentDifferentPidFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/TtContentDeletedLocalizedParentExistsTest.php
@@ -50,7 +50,7 @@ class TtContentDeletedLocalizedParentExistsTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentDeletedLocalizedParentExistsImport.csv');
         /** @var TtContentDeletedLocalizedParentExists $subject */
         $subject = $this->get(TtContentDeletedLocalizedParentExists::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentDeletedLocalizedParentExistsFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentLocalizationSourceExistsTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizationSourceExistsTest.php
@@ -50,7 +50,7 @@ class TtContentLocalizationSourceExistsTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizationSourceExistsImport.csv');
         /** @var TtContentLocalizationSourceExists $subject */
         $subject = $this->get(TtContentLocalizationSourceExists::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizationSourceExistsFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentLocalizationSourceLogicWithParentTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizationSourceLogicWithParentTest.php
@@ -46,7 +46,7 @@ class TtContentLocalizationSourceLogicWithParentTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizationSourceLogicWithParentImport.csv');
         /** @var TtContentLocalizationSourceLogicWithParent $subject */
         $subject = $this->get(TtContentLocalizationSourceLogicWithParent::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizationSourceLogicWithParentFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentLocalizationSourceSetWithParentTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizationSourceSetWithParentTest.php
@@ -50,7 +50,7 @@ class TtContentLocalizationSourceSetWithParentTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizationSourceSetWithParentImport.csv');
         /** @var TtContentLocalizationSourceSetWithParent $subject */
         $subject = $this->get(TtContentLocalizationSourceSetWithParent::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizationSourceSetWithParentFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentLocalizedDuplicatesTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedDuplicatesTest.php
@@ -46,7 +46,7 @@ class TtContentLocalizedDuplicatesTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizedDuplicatesImport.csv');
         /** @var TtContentLocalizedDuplicates $subject */
         $subject = $this->get(TtContentLocalizedDuplicates::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizedDuplicatesFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentLocalizedParentDifferentPidTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedParentDifferentPidTest.php
@@ -50,7 +50,7 @@ class TtContentLocalizedParentDifferentPidTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizedParentDifferentPidImport.csv');
         /** @var TtContentLocalizedParentDifferentPid $subject */
         $subject = $this->get(TtContentLocalizedParentDifferentPid::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizedParentDifferentPidFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentLocalizedParentExistsTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedParentExistsTest.php
@@ -50,7 +50,7 @@ class TtContentLocalizedParentExistsTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizedParentExistsImport.csv');
         /** @var TtContentLocalizedParentExists $subject */
         $subject = $this->get(TtContentLocalizedParentExists::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizedParentExistsFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentLocalizedParentSoftDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TtContentLocalizedParentSoftDeletedTest.php
@@ -50,7 +50,7 @@ class TtContentLocalizedParentSoftDeletedTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizedParentSoftDeletedImport.csv');
         /** @var TtContentLocalizedParentSoftDeleted $subject */
         $subject = $this->get(TtContentLocalizedParentSoftDeleted::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentLocalizedParentSoftDeletedFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentPidDeletedTest.php
+++ b/Tests/Functional/HealthCheck/TtContentPidDeletedTest.php
@@ -50,7 +50,7 @@ class TtContentPidDeletedTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentPidDeletedImport.csv');
         /** @var TtContentPidDeleted $subject */
         $subject = $this->get(TtContentPidDeleted::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentPidDeletedFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/TtContentPidMissingTest.php
+++ b/Tests/Functional/HealthCheck/TtContentPidMissingTest.php
@@ -50,7 +50,7 @@ class TtContentPidMissingTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TtContentPidMissingImport.csv');
         /** @var TtContentPidMissing $subject */
         $subject = $this->get(TtContentPidMissing::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/TtContentPidMissingFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/WorkspacesNotLoadedRecordsDanglingWorkspacesLoadedTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesNotLoadedRecordsDanglingWorkspacesLoadedTest.php
@@ -49,7 +49,7 @@ class WorkspacesNotLoadedRecordsDanglingWorkspacesLoadedTest extends FunctionalT
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesNotLoadedRecordsDanglingImport.csv');
         /** @var WorkspacesNotLoadedRecordsDangling $subject */
         $subject = $this->get(WorkspacesNotLoadedRecordsDangling::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesNotLoadedRecordsDanglingWorkspacesLoadedFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/WorkspacesNotLoadedRecordsDanglingWorkspacesNotLoadedTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesNotLoadedRecordsDanglingWorkspacesNotLoadedTest.php
@@ -46,7 +46,7 @@ class WorkspacesNotLoadedRecordsDanglingWorkspacesNotLoadedTest extends Function
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesNotLoadedRecordsDanglingImport.csv');
         /** @var WorkspacesNotLoadedRecordsDangling $subject */
         $subject = $this->get(WorkspacesNotLoadedRecordsDangling::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesNotLoadedRecordsDanglingWorkspacesNotLoadedFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/WorkspacesRecordsOfDeletedWorkspacesTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesRecordsOfDeletedWorkspacesTest.php
@@ -50,7 +50,7 @@ class WorkspacesRecordsOfDeletedWorkspacesTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesRecordsOfDeletedWorkspacesImport.csv');
         /** @var WorkspacesRecordsOfDeletedWorkspaces $subject */
         $subject = $this->get(WorkspacesRecordsOfDeletedWorkspaces::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesRecordsOfDeletedWorkspacesFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/WorkspacesSoftDeletedRecordsTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesSoftDeletedRecordsTest.php
@@ -50,7 +50,7 @@ class WorkspacesSoftDeletedRecordsTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesSoftDeletedRecordsImport.csv');
         /** @var WorkspacesSoftDeletedRecords $subject */
         $subject = $this->get(WorkspacesSoftDeletedRecords::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesSoftDeletedRecordsFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/WorkspacesT3verStateMinusOneTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesT3verStateMinusOneTest.php
@@ -50,7 +50,7 @@ class WorkspacesT3verStateMinusOneTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesT3verStateMinusOneImport.csv');
         /** @var WorkspacesT3verStateMinusOne $subject */
         $subject = $this->get(WorkspacesT3verStateMinusOne::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesT3verStateMinusOneFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/WorkspacesT3verStateNotZeroInLiveTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesT3verStateNotZeroInLiveTest.php
@@ -50,7 +50,7 @@ class WorkspacesT3verStateNotZeroInLiveTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesT3verStateNotZeroInLiveImport.csv');
         /** @var WorkspacesT3verStateNotZeroInLive $subject */
         $subject = $this->get(WorkspacesT3verStateNotZeroInLive::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesT3verStateNotZeroInLiveFixed.csv');
     }
 }

--- a/Tests/Functional/HealthCheck/WorkspacesT3verStateThreeTest.php
+++ b/Tests/Functional/HealthCheck/WorkspacesT3verStateThreeTest.php
@@ -50,7 +50,7 @@ class WorkspacesT3verStateThreeTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesT3verStateThreeImport.csv');
         /** @var WorkspacesT3verStateThree $subject */
         $subject = $this->get(WorkspacesT3verStateThree::class);
-        $subject->handle($this->createMock(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
+        $subject->handle(self::createStub(SymfonyStyle::class), HealthCheckInterface::MODE_EXECUTE, '');
         $this->assertCSVDataSet(__DIR__ . '/../Fixtures/WorkspacesT3verStateThreeFixed.csv');
     }
 }


### PR DESCRIPTION
Avoids PHPUnit 12 'MockObjectExpectationsRequired' notice on PHP 8.3+.